### PR TITLE
feat(pipeline): sliced delegation (test-gated vertical slices)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "claude-architect",
       "displayName": "Claude Architect",
       "source": "./",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "description": "Verified P0-A MCP delegation with macOS arm64 certified; Linux tested; native Windows pending. Codex edit eligibility requires its proven native sandbox.",
       "author": {
         "name": "elkaix",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-architect",
   "displayName": "Claude Architect",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Verified coding-agent delegation for Claude Code with isolated Producers, frozen candidate artifacts, independent review, and human-controlled integration.",
   "author": {
     "name": "Mohamed Elkholy",

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -17,32 +17,65 @@ npx tsc --noEmit
 echo "[pre-push] full test suite"
 npx vitest run --silent
 
-# Pushing main or a tag is a release-facing action: also run the release validator.
+# Record which refs are being pushed (stdin is consumed here; read it once).
 release_push=0
 tag_push=0
+pushed_branches=()
 while read -r _local_ref _local_sha remote_ref _remote_sha; do
   case "$remote_ref" in
-    refs/heads/main) release_push=1 ;;
+    refs/heads/main) release_push=1; pushed_branches+=("main") ;;
+    refs/heads/*) pushed_branches+=("${remote_ref#refs/heads/}") ;;
     refs/tags/*) release_push=1; tag_push=1 ;;
   esac
 done
 
+# The local suite above runs on ONE OS. Cross-platform jobs (Linux/macOS/Windows)
+# only run in CI, so a platform-specific failure — like a POSIX-only file op that
+# EPERMs on Windows — is invisible here. Actual CI conclusions are the only signal.
+# Return the latest COMPLETED CI conclusion for a branch, else "none".
+branch_ci_conclusion() {
+  command -v gh >/dev/null 2>&1 || { echo "none"; return; }
+  gh run list --branch "$1" --limit 1 --json status,conclusion \
+    --jq 'if (.[0].status // "") == "completed" then (.[0].conclusion // "none") else "none" end' \
+    2>/dev/null || echo "none"
+}
+
+# A red base branch cannot be run locally, so inheriting its failures via a
+# merge/rebase is invisible to the suite above. Surface it loudly on every push.
+main_ci=$(branch_ci_conclusion main)
+if [ "$main_ci" = "failure" ]; then
+  echo "[pre-push] WARNING: latest CI on origin/main is FAILING — a merge/rebase inherits its red." >&2
+  echo "[pre-push]   Inspect: gh run list --branch main --limit 1" >&2
+fi
+
+# Refuse to stack more work on, or merge, a branch whose latest CI is already red
+# (e.g. a platform-only failure the local suite never sees). This turns "CI went
+# red and nobody noticed" into a hard stop at the next push.
+for br in "${pushed_branches[@]}"; do
+  [ "$br" = "main" ] && continue  # main handled by the release block below
+  concl=$(branch_ci_conclusion "$br")
+  if [ "$concl" = "failure" ]; then
+    echo "[pre-push] ERROR: latest CI on '$br' is FAILING (includes cross-platform jobs the local suite cannot run)." >&2
+    echo "[pre-push]   Inspect: gh run list --branch $br --limit 1" >&2
+    echo "[pre-push]   Fix CI first. If THIS push IS the fix, re-run: git push --no-verify" >&2
+    exit 1
+  fi
+done
+
+# Pushing main or a tag is a release-facing action: also run the release validator.
 if [ "$release_push" -eq 1 ]; then
   echo "[pre-push] release validator (main/tag push)"
   bash scripts/validate-release.sh
 
-  # Cross-platform CI cannot run locally. A tag must never be cut on red CI;
-  # a main push on red CI is allowed (it may BE the fix) but warns loudly.
-  if command -v gh >/dev/null 2>&1; then
-    latest=$(gh run list --branch main --limit 1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
-    if [ "$latest" = "failure" ]; then
-      if [ "$tag_push" -eq 1 ]; then
-        echo "[pre-push] ERROR: latest CI on origin/main is FAILING — refusing to push a tag." >&2
-        echo "[pre-push] Fix CI first, or bypass knowingly with --no-verify." >&2
-        exit 1
-      fi
-      echo "[pre-push] WARNING: latest CI on origin/main is FAILING — this push should fix it." >&2
+  # A tag must never be cut on red CI; a main push on red CI is allowed (it may BE
+  # the fix) but warns loudly.
+  if [ "$main_ci" = "failure" ]; then
+    if [ "$tag_push" -eq 1 ]; then
+      echo "[pre-push] ERROR: latest CI on origin/main is FAILING — refusing to push a tag." >&2
+      echo "[pre-push] Fix CI first, or bypass knowingly with --no-verify." >&2
+      exit 1
     fi
+    echo "[pre-push] WARNING: latest CI on origin/main is FAILING — this push should fix it." >&2
   fi
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ Repository maintainers should enable the push gate once per clone:
 git config core.hooksPath .githooks
 ```
 
-Agents must not change Git configuration unless the user explicitly requests it. `.githooks/pre-push` runs TypeScript and the full Vitest suite for every push. Pushes to `main` or a tag also run release validation and check the latest `origin/main` CI conclusion.
+Agents must not change Git configuration unless the user explicitly requests it. `.githooks/pre-push` runs TypeScript and the full Vitest suite for every push. Because that suite runs on one OS, cross-platform (Linux/macOS/Windows) failures only appear in CI; the hook therefore also consults actual CI conclusions via `gh`: it **refuses** to push more onto a feature branch whose latest completed CI is `failure` (use `git push --no-verify` only when the push itself is the fix), and it **warns** whenever `origin/main` CI is red so an inherited failure is visible before a merge or rebase. Pushes to `main` or a tag additionally run release validation, and a tag push is hard-blocked when `origin/main` CI is failing. These CI checks degrade gracefully to no-ops when `gh` is unavailable, so they cannot fully substitute for green cross-platform CI—never merge or tag on a red Windows/Linux run.
 
 ## Git safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ All notable changes to Claude Architect are recorded here. The format follows
   completed slice advance/repair/halt from its verification result alone. Review
   and the advisor judge the composed candidate over the whole slice branch at the
   end; per-slice review is opt-in via `review.perSlice: true`. A mid-run halt
-  yields a partial `human-decision-required` candidate carrying `haltedSliceIndex`
-  and each slice's route in `slices`, which only the human decides.
+  after at least one slice has advanced yields a partial `human-decision-required`
+  candidate — the promoted advanced-slice branch, which the human may accept,
+  reject, or revise — carrying `haltedSliceIndex` and each slice's route in
+  `slices`; a halt on the first slice with nothing advanced is reported `failed`
+  with the slice evidence retained.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to Claude Architect are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-19
+
+### Added
+
+- Sliced delegation: a spec may carry a top-level `slices` array that decomposes
+  the task into ordered, independently testable steps. Each slice is a scoped
+  mini-spec with its own `writeAllowlist` (a subset of the spec's),
+  `forbiddenScope`, `successCriteria`, and required `verification`, and runs
+  fresh with no context from prior slices. A deterministic wayfinder routes each
+  completed slice advance/repair/halt from its verification result alone. Review
+  and the advisor judge the composed candidate over the whole slice branch at the
+  end; per-slice review is opt-in via `review.perSlice: true`. A mid-run halt
+  yields a partial `human-decision-required` candidate carrying `haltedSliceIndex`
+  and each slice's route in `slices`, which only the human decides.
+
+### Changed
+
+- The `delegatePipeline` result now exposes `slices` (per-slice routes) and
+  `haltedSliceIndex` on the MCP wire. The MCP tool protocol advances 1.2.0 to
+  1.3.0 (additive).
+
 ## [0.20.0] - 2026-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-plugin-d97757?style=flat-square&labelColor=0b0e14">
   <img alt="OpenCode" src="https://img.shields.io/badge/OpenCode-native-58a6ff?style=flat-square&labelColor=0b0e14">
-  <img alt="version" src="https://img.shields.io/badge/version-0.20.0-9aa4b2?style=flat-square&labelColor=0b0e14">
+  <img alt="version" src="https://img.shields.io/badge/version-0.21.0-9aa4b2?style=flat-square&labelColor=0b0e14">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-3fb950?style=flat-square&labelColor=0b0e14">
 </p>
 

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -27063,7 +27063,7 @@ var ArtifactStore = class {
     }
   }
   async writePipelineActiveMarker(marker) {
-    if (typeof marker !== "object" || marker === null || !Number.isSafeInteger(marker.pid) || marker.pid <= 1 || marker.processToken !== null && typeof marker.processToken !== "string" || typeof marker.startedAt !== "string" || !Number.isFinite(Date.parse(marker.startedAt))) {
+    if (typeof marker !== "object" || marker === null || !Number.isSafeInteger(marker.pid) || marker.pid <= 1 || marker.processToken !== null && typeof marker.processToken !== "string" || typeof marker.startedAt !== "string" || !Number.isFinite(Date.parse(marker.startedAt)) || typeof marker.sliced !== "boolean") {
       throw new RuntimeError("pipeline-active marker is invalid");
     }
     await this.replaceJson("pipeline-active.json", marker);
@@ -27078,10 +27078,13 @@ var ArtifactStore = class {
         path9.join(validated.path, "pipeline-active.json"),
         validated.identity
       ));
-      if (typeof value !== "object" || value === null || typeof value.pid !== "number" || !Number.isSafeInteger(value.pid) || value.pid <= 1 || value.processToken !== null && typeof value.processToken !== "string" || typeof value.startedAt !== "string" || !Number.isFinite(Date.parse(value.startedAt))) {
+      if (typeof value !== "object" || value === null || typeof value.pid !== "number" || !Number.isSafeInteger(value.pid) || value.pid <= 1 || value.processToken !== null && typeof value.processToken !== "string" || typeof value.startedAt !== "string" || !Number.isFinite(Date.parse(value.startedAt)) || value.sliced !== void 0 && typeof value.sliced !== "boolean") {
         throw new RuntimeError("archived pipeline-active marker is malformed");
       }
-      return value;
+      return {
+        ...value,
+        sliced: value.sliced ?? false
+      };
     } catch (error2) {
       if (isMissing(error2)) return null;
       throw error2;
@@ -28031,7 +28034,7 @@ async function runAttempt(checkoutPath, spec, deps) {
       startedAt: new Date(startedAtMs).toISOString()
     };
     const runStartContext = await initializeRunStart(store, runStart);
-    deps.onRunStart?.(runStartContext);
+    await deps.onRunStart?.(runStartContext);
     worktree = await new WorktreeManager(canonical.canonical, runId, ps).create(
       preconditions.baseCommitOid
     );
@@ -29816,6 +29819,13 @@ async function runPipeline(checkoutPath, spec, deps) {
   const runAttemptFn = deps.runAttempt ?? runAttempt;
   const slices = resolveSlices(spec);
   const initialSpec = slices.length === 0 ? spec : scopeSpecToSlice(spec, slices[0]);
+  const ps = deps.ps ?? getPlatformServices();
+  const activeOwner = {
+    pid: process.pid,
+    processToken: await ps.getProcessStartToken(process.pid).catch(() => null),
+    startedAt: (/* @__PURE__ */ new Date()).toISOString(),
+    sliced: slices.length > 0
+  };
   const notePhase = (phase) => {
     try {
       deps.onPhase?.(phase);
@@ -29823,15 +29833,22 @@ async function runPipeline(checkoutPath, spec, deps) {
     }
   };
   let runStart;
+  let slicedMarkerEstablished = false;
   const inheritedOnRunStart = deps.onRunStart;
   const attempt = await runAttemptFn(checkoutPath, initialSpec, {
     ...deps,
-    onRunStart(context) {
+    async onRunStart(context) {
       runStart = context;
-      inheritedOnRunStart?.(context);
+      if (slices.length > 0) {
+        await new ArtifactStore(context.record.runId).writePipelineActiveMarker(activeOwner);
+        slicedMarkerEstablished = true;
+      }
+      await inheritedOnRunStart?.(context);
     }
   });
+  const store = new ArtifactStore(attempt.runId);
   if (attempt.status !== "verified-candidate" || attempt.candidate === null) {
+    if (slicedMarkerEstablished) await store.clearPipelineActiveMarker();
     return failedResult(
       attempt,
       [],
@@ -29840,16 +29857,10 @@ async function runPipeline(checkoutPath, spec, deps) {
       attempt.failure ?? "producer-failure"
     );
   }
-  const store = new ArtifactStore(attempt.runId);
-  const ps = deps.ps ?? getPlatformServices();
-  const activeOwner = {
-    pid: process.pid,
-    processToken: await ps.getProcessStartToken(process.pid).catch(() => null),
-    startedAt: (/* @__PURE__ */ new Date()).toISOString()
-  };
-  await store.writePipelineActiveMarker(activeOwner);
+  if (slices.length === 0) await store.writePipelineActiveMarker(activeOwner);
   const temporarySliceRefs2 = [];
   let finalAttempt = attempt;
+  let authoritySafeToRelease = slices.length === 0;
   let pipelinePrimaryError;
   try {
     const reviewConfig = resolveReviewConfig(spec);
@@ -29869,6 +29880,7 @@ async function runPipeline(checkoutPath, spec, deps) {
         reason: args.reason,
         store
       });
+      if (slices.length > 0) authoritySafeToRelease = true;
       finalAttempt = failedAttempt;
       return failedResult(
         failedAttempt,
@@ -29912,6 +29924,7 @@ async function runPipeline(checkoutPath, spec, deps) {
           });
         } catch (error2) {
           const archived = await archiveSliceExecutionError({ error: error2, attempt, store });
+          authoritySafeToRelease = true;
           finalAttempt = archived.failedAttempt;
           if (error2 !== archived.sliceError) throw error2;
           const failed = failedResult(
@@ -30074,6 +30087,7 @@ async function runPipeline(checkoutPath, spec, deps) {
         });
       } catch (error2) {
         const archived = await archiveSliceExecutionError({ error: error2, attempt, store });
+        authoritySafeToRelease = true;
         finalAttempt = archived.failedAttempt;
         if (error2 !== archived.sliceError) throw error2;
         const failed = failedResult(
@@ -30099,6 +30113,7 @@ async function runPipeline(checkoutPath, spec, deps) {
           reason,
           store
         });
+        authoritySafeToRelease = true;
         finalAttempt = failedAttempt;
         const failed = failedResult(
           failedAttempt,
@@ -30444,6 +30459,7 @@ async function runPipeline(checkoutPath, spec, deps) {
       failure: null
     };
     await store.writePipelineArtifact("pipeline-result", result);
+    authoritySafeToRelease = true;
     return result;
   } catch (error2) {
     let terminalError = error2;
@@ -30455,6 +30471,7 @@ async function runPipeline(checkoutPath, spec, deps) {
           reason: "sliced pipeline terminated before completing trusted gates",
           store
         });
+        authoritySafeToRelease = true;
       } catch (archiveError) {
         terminalError = new AggregateError(
           [error2, archiveError],
@@ -30466,7 +30483,6 @@ async function runPipeline(checkoutPath, spec, deps) {
     throw terminalError;
   } finally {
     const cleanupErrors = await cleanupTemporarySliceRefs(checkoutPath, temporarySliceRefs2);
-    let canClearActiveMarker = true;
     if (cleanupErrors.length > 0 && slices.length > 0 && finalAttempt.status === "verified-candidate") {
       try {
         finalAttempt = await archiveSlicedFailure({
@@ -30475,12 +30491,12 @@ async function runPipeline(checkoutPath, spec, deps) {
           reason: "temporary slice ref cleanup did not complete",
           store
         });
+        authoritySafeToRelease = true;
       } catch (archiveError) {
         cleanupErrors.push(archiveError);
-        canClearActiveMarker = false;
       }
     }
-    if (canClearActiveMarker) {
+    if (cleanupErrors.length === 0 && authoritySafeToRelease) {
       try {
         await store.clearPipelineActiveMarker();
       } catch (cleanupError) {
@@ -31207,7 +31223,9 @@ async function temporarySliceRefs(repoRoot, runId, runGit) {
     if (fields[1] === void 0 || !OID.test(fields[1])) {
       throw new RuntimeError("temporary slice ref OID is malformed during recovery");
     }
-    const object3 = await runGit(repoRoot, ["cat-file", "-t", fields[1]]);
+    const object3 = await runGit(repoRoot, ["cat-file", "-t", fields[1]], {
+      env: { GIT_NO_REPLACE_OBJECTS: "1" }
+    });
     if (object3.exitCode !== 0 || object3.stdout.trim() !== "commit") {
       throw new RuntimeError("temporary slice ref does not identify a commit during recovery");
     }
@@ -31527,7 +31545,7 @@ async function recoverStaleRuns(dependencies = {}) {
           (pid) => ps.getProcessStartToken(pid)
         )) {
           const commonDir = await validateGitCommonDir(record2.canonicalCommonDir);
-          await archiveInterruptedPipeline(store, result);
+          if (marker.sliced) await archiveInterruptedPipeline(store, result);
           await cleanupManagedWorktrees(commonDir, root, entry.name, ps);
           await cleanupTemporarySliceRefs2(commonDir, entry.name, runGit);
           await store.clearPipelineActiveMarker();

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -27134,11 +27134,11 @@ var ArtifactStore = class {
     }));
     return entries.filter((entry) => entry !== null).sort(compareEntries);
   }
-  async prepareCandidateAnchorCleanup(runId, result) {
+  async prepareCandidateAnchorCleanup(runId, result, manifest, canonicalRepoRoot) {
     if (result.candidate === null) {
       return {
         outcome: "not-applicable",
-        repoRoot: null,
+        repoRoot: canonicalRepoRoot,
         anchorRef: null,
         backupRef: null,
         candidateCommitOid: null
@@ -27152,14 +27152,9 @@ var ArtifactStore = class {
     if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(candidate.candidateCommitOid)) {
       throw new RuntimeError("archived candidate commit oid is invalid");
     }
-    const manifest = await this.readManifest(runId);
-    if (manifest === null) {
-      throw new RuntimeError("cannot remove candidate anchor without archived repository root");
-    }
     if (manifest.baseCommitOid !== candidate.baseCommitOid || manifest.candidateManifestHash !== candidate.manifestHash) {
       throw new RuntimeError("archived candidate does not match its run manifest");
     }
-    const canonicalRepoRoot = await realpath3(manifest.repoRoot);
     const repositoryTopLevel = await git(canonicalRepoRoot, ["rev-parse", "--show-toplevel"]);
     if (repositoryTopLevel.exitCode !== 0 || await realpath3(repositoryTopLevel.stdout.trim()) !== canonicalRepoRoot) {
       throw new RuntimeError("archived repository root is not a canonical repository root");
@@ -27301,7 +27296,7 @@ var ArtifactStore = class {
       await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
     });
   }
-  async prune(policy) {
+  async prune(policy, dependencies = {}) {
     validatePruneLimit(policy.maxAgeMs, "maxAgeMs");
     validatePruneLimit(policy.maxBytes, "maxBytes");
     const entries = await this.entries();
@@ -27318,13 +27313,54 @@ var ArtifactStore = class {
       let transaction = null;
       let runsRootIdentity = null;
       let archiveRemovalCommitted = false;
+      let lease = null;
       try {
+        if (await this.readPipelineActiveMarker(entry.runId) !== null) {
+          retained.push({ runId: entry.runId, reason: "active-run" });
+          return;
+        }
+        const initialManifest = await this.readManifest(entry.runId);
+        if (initialManifest === null) {
+          retained.push({ runId: entry.runId, reason: "incomplete-run" });
+          return;
+        }
+        const initialResult = await this.readResult(entry.runId);
+        if (initialResult === null) {
+          retained.push({ runId: entry.runId, reason: "incomplete-run" });
+          return;
+        }
+        const platformServices = dependencies.platformServices ?? getPlatformServices();
+        const canonical = await platformServices.canonicalizePath(initialManifest.repoRoot);
+        const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
+        lease = await platformServices.acquireCheckoutLock(canonical.canonical);
+        if (lease.repositoryIdentity !== repositoryIdentity) {
+          throw new RuntimeError("checkout lease repository identity changed before pruning");
+        }
+        await assertDirectoryIdentity(entry.directory, entry.identity);
+        const currentManifest = await this.readManifest(entry.runId);
+        if (currentManifest === null || serializeJson(currentManifest) !== serializeJson(initialManifest)) {
+          retained.push({ runId: entry.runId, reason: "run identity changed while waiting" });
+          return;
+        }
+        if (await this.readPipelineActiveMarker(entry.runId) !== null) {
+          retained.push({ runId: entry.runId, reason: "active-run" });
+          return;
+        }
         const result = await this.readResult(entry.runId);
         if (result === null) {
           retained.push({ runId: entry.runId, reason: "incomplete-run" });
           return;
         }
-        prepared = await this.prepareCandidateAnchorCleanup(entry.runId, result);
+        if (serializeJson(result) !== serializeJson(initialResult)) {
+          retained.push({ runId: entry.runId, reason: "terminal authority changed while waiting" });
+          return;
+        }
+        prepared = await this.prepareCandidateAnchorCleanup(
+          entry.runId,
+          result,
+          currentManifest,
+          canonical.canonical
+        );
         await this.appendCleanupRecord({
           event: "prune-cleanup-intent",
           runId: entry.runId,
@@ -27417,6 +27453,18 @@ var ArtifactStore = class {
             runId: entry.runId,
             reason: redact(`${primary}${rollback}`)
           });
+        }
+      } finally {
+        if (lease !== null) {
+          try {
+            await lease.release();
+          } catch (error2) {
+            const reason2 = redact(error2 instanceof Error ? error2.message : String(error2));
+            retained.push({
+              runId: entry.runId,
+              reason: archiveRemovalCommitted ? `archive removed; checkout lease release failed: ${reason2}` : reason2
+            });
+          }
         }
       }
     };
@@ -31406,14 +31454,15 @@ function parseCleanupRecord(line) {
     throw new RuntimeError("terminal cleanup journal record cannot remain pending");
   }
   const hasRepository = typeof record2.repoRoot === "string" && typeof record2.anchorRef === "string" && typeof record2.candidateCommitOid === "string";
+  const repositoryOnly = typeof record2.repoRoot === "string" && record2.anchorRef === null && record2.backupRef === null && record2.candidateCommitOid === null;
   const noRepository = record2.repoRoot === null && record2.anchorRef === null && record2.backupRef === null && record2.candidateCommitOid === null;
-  if (!noRepository && (!hasRepository || record2.anchorRef !== `${CANDIDATE_REF_PREFIX3}${record2.runId}` || !OID.test(record2.candidateCommitOid) || record2.backupRef !== null && record2.backupRef !== `${BACKUP_REF_PREFIX}${record2.runId}`)) {
+  if (!noRepository && !repositoryOnly && (!hasRepository || record2.anchorRef !== `${CANDIDATE_REF_PREFIX3}${record2.runId}` || !OID.test(record2.candidateCommitOid) || record2.backupRef !== null && record2.backupRef !== `${BACKUP_REF_PREFIX}${record2.runId}`)) {
     throw new RuntimeError("cleanup journal Git metadata is malformed");
   }
   return record2;
 }
 function cleanupOutcome(record2) {
-  if (record2.repoRoot === null) return "not-applicable";
+  if (record2.repoRoot === null || record2.anchorRef === null) return "not-applicable";
   return record2.backupRef === null ? "already-absent" : "deleted";
 }
 async function appendCleanupRecord(runsRoot, record2) {
@@ -31494,7 +31543,7 @@ async function commitCleanupRefs(record2) {
   }
   await deleteExactRef(repoRoot, record2.backupRef, backupOid);
 }
-async function replayInterruptedPrunes(runsRoot) {
+async function replayInterruptedPrunes(runsRoot, ps) {
   const text = await readCleanupJournal(path14.join(runsRoot, "cleanup.ndjson"));
   if (text === null || text.trim() === "") return;
   const pending = /* @__PURE__ */ new Map();
@@ -31505,30 +31554,63 @@ async function replayInterruptedPrunes(runsRoot) {
     else pending.delete(record2.runId);
   }
   for (const record2 of [...pending.values()].sort((left, right) => left.runId.localeCompare(right.runId))) {
-    const runDirectory = path14.join(runsRoot, record2.runId);
-    const quarantinePath = path14.join(runsRoot, record2.quarantineName);
-    const runIdentity = await plainDirectoryIdentity(runDirectory);
-    const quarantineIdentity = await plainDirectoryIdentity(quarantinePath);
-    if (runIdentity !== null && quarantineIdentity !== null) {
-      throw new RuntimeError("both retained and quarantined run archives exist during recovery");
+    if (record2.repoRoot === null) continue;
+    const repoRoot = await validateRepositoryRoot(record2.repoRoot);
+    const commonResult = await git(repoRoot, [
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-common-dir"
+    ]);
+    if (commonResult.exitCode !== 0) {
+      throw runGitError("resolve cleanup repository identity", commonResult);
     }
-    const action = runIdentity !== null ? "rollback" : "finish";
-    const outcome = await reconcileCleanupRefs(record2, action);
-    if (action === "finish") {
-      if (quarantineIdentity !== null) {
-        await removePlainDirectory(quarantinePath, quarantineIdentity);
+    const repositoryIdentity = await realpath6(commonResult.stdout.trim());
+    const lease = await ps.acquireCheckoutLock(repoRoot);
+    let primaryError;
+    try {
+      if (lease.repositoryIdentity !== repositoryIdentity) {
+        throw new RuntimeError("checkout lease repository identity changed during prune recovery");
       }
-      await commitCleanupRefs(record2);
+      const runDirectory = path14.join(runsRoot, record2.runId);
+      const quarantinePath = path14.join(runsRoot, record2.quarantineName);
+      const runIdentity = await plainDirectoryIdentity(runDirectory);
+      const quarantineIdentity = await plainDirectoryIdentity(quarantinePath);
+      if (runIdentity !== null && quarantineIdentity !== null) {
+        throw new RuntimeError("both retained and quarantined run archives exist during recovery");
+      }
+      const action = runIdentity !== null ? "rollback" : "finish";
+      const outcome = await reconcileCleanupRefs(record2, action);
+      if (action === "finish") {
+        if (quarantineIdentity !== null) {
+          await removePlainDirectory(quarantinePath, quarantineIdentity);
+        }
+        await commitCleanupRefs(record2);
+      }
+      await appendCleanupRecord(runsRoot, {
+        ...record2,
+        event: action === "finish" ? "prune-cleanup-complete" : "prune-cleanup-rollback",
+        anchorCleanup: outcome,
+        recordedAt: (/* @__PURE__ */ new Date()).toISOString()
+      });
+    } catch (error2) {
+      primaryError = error2;
+    } finally {
+      try {
+        await lease.release();
+      } catch (releaseError) {
+        if (primaryError !== void 0) {
+          throw new AggregateError(
+            [primaryError, releaseError],
+            "prune recovery failed and its checkout lease could not be released"
+          );
+        }
+        throw releaseError;
+      }
     }
-    await appendCleanupRecord(runsRoot, {
-      ...record2,
-      event: action === "finish" ? "prune-cleanup-complete" : "prune-cleanup-rollback",
-      anchorCleanup: outcome,
-      recordedAt: (/* @__PURE__ */ new Date()).toISOString()
-    });
+    if (primaryError !== void 0) throw primaryError;
   }
 }
-async function recoverRun(record2, root, ps, isProcessAlive, requestCooperativeTermination, delayMs, graceMs, runGit) {
+async function recoverRun(record2, root, ps, isProcessAlive, requestCooperativeTermination, delayMs, graceMs, runGit, locksRoot) {
   let escalation;
   if (record2.pid !== null && isProcessAlive(record2.pid)) {
     const liveToken = record2.processToken === null ? null : await ps.getProcessStartToken(record2.pid);
@@ -31543,38 +31625,99 @@ async function recoverRun(record2, root, ps, isProcessAlive, requestCooperativeT
       }
     }
   }
-  const commonDir = await validateGitCommonDir(record2.canonicalCommonDir);
-  const store = new ArtifactStore(record2.runId);
-  const logsRef = await store.writeLog(
-    "recovery",
-    "startup recovery reclaimed unfinished run\n"
+  await reclaimExactLock(
+    locksRoot,
+    record2.lockKey,
+    isProcessAlive,
+    (pid) => ps.getProcessStartToken(pid)
   );
-  await cleanupManagedWorktrees(commonDir, root, record2.runId, ps);
-  await cleanupTemporarySliceRefs2(commonDir, record2.runId, runGit);
-  await removeStaleCandidateAnchor(commonDir, record2.runId);
-  await store.writeResult({
-    resultVersion: "1",
-    runId: record2.runId,
-    status: "cancelled",
-    failure: "cancelled",
-    summary: "Interrupted attempt was cancelled during startup recovery.",
-    producerSummary: null,
-    candidate: null,
-    requestedVerification: [],
-    executedVerification: [],
-    unresolvedIssues: ["attempt-interrupted-before-terminal-result"],
-    evidence: {
-      recovery: "startup-stale-run",
-      originalStartedAt: record2.startedAt,
-      ...escalation === void 0 ? {} : { escalation }
-    },
-    logsRef,
-    producerId: null,
-    producerVersion: null,
-    producerModel: null,
-    durationMs: Math.max(0, Date.now() - Date.parse(record2.startedAt)),
-    sessionId: null
-  });
+  const commonDir = await validateGitCommonDir(record2.canonicalCommonDir);
+  const lease = await ps.acquireCheckoutLock(commonDir);
+  let primaryError;
+  let recovered = false;
+  try {
+    if (lease.repositoryIdentity !== commonDir) {
+      throw new RuntimeError("checkout lease repository identity changed during recovery");
+    }
+    const store = new ArtifactStore(record2.runId);
+    const currentRunStartText = await readBoundedRegularFile(
+      path14.join(store.runDirectory, "run-start.json")
+    );
+    if (currentRunStartText === null) return false;
+    const currentRecord = parseRunStart(currentRunStartText, record2.runId);
+    if (currentRecord.canonicalCommonDir !== commonDir || currentRecord.lockKey !== record2.lockKey) {
+      throw new RuntimeError("run-start repository identity changed during recovery");
+    }
+    const result = await store.readResult(record2.runId);
+    const marker = await store.readPipelineActiveMarker(record2.runId);
+    if (marker !== null && await lockOwnerIsLive(
+      { pid: marker.pid, processToken: marker.processToken },
+      isProcessAlive,
+      (pid) => ps.getProcessStartToken(pid)
+    )) return false;
+    if (result !== null) {
+      validateTerminalResult(result, record2.runId);
+      if (marker === null) return false;
+      if (marker.sliced) await archiveInterruptedPipeline(store, result);
+      await cleanupManagedWorktrees(commonDir, root, record2.runId, ps);
+      await cleanupTemporarySliceRefs2(commonDir, record2.runId, runGit);
+      await store.clearPipelineActiveMarker();
+      return false;
+    }
+    if (currentRecord.pid !== null && isProcessAlive(currentRecord.pid)) {
+      const token = currentRecord.processToken === null ? null : await ps.getProcessStartToken(currentRecord.pid);
+      const ownerIsLive = currentRecord.processToken === null || token === currentRecord.processToken;
+      const isExactTerminatedOwner = escalation !== void 0 && currentRecord.pid === record2.pid && currentRecord.processToken === record2.processToken;
+      if (ownerIsLive && !isExactTerminatedOwner) return false;
+    }
+    const logsRef = await store.writeLog(
+      "recovery",
+      "startup recovery reclaimed unfinished run\n"
+    );
+    await cleanupManagedWorktrees(commonDir, root, record2.runId, ps);
+    await cleanupTemporarySliceRefs2(commonDir, record2.runId, runGit);
+    await removeStaleCandidateAnchor(commonDir, record2.runId);
+    await store.writeResult({
+      resultVersion: "1",
+      runId: record2.runId,
+      status: "cancelled",
+      failure: "cancelled",
+      summary: "Interrupted attempt was cancelled during startup recovery.",
+      producerSummary: null,
+      candidate: null,
+      requestedVerification: [],
+      executedVerification: [],
+      unresolvedIssues: ["attempt-interrupted-before-terminal-result"],
+      evidence: {
+        recovery: "startup-stale-run",
+        originalStartedAt: record2.startedAt,
+        ...escalation === void 0 ? {} : { escalation }
+      },
+      logsRef,
+      producerId: null,
+      producerVersion: null,
+      producerModel: null,
+      durationMs: Math.max(0, Date.now() - Date.parse(record2.startedAt)),
+      sessionId: null
+    });
+    recovered = true;
+  } catch (error2) {
+    primaryError = error2;
+  } finally {
+    try {
+      await lease.release();
+    } catch (releaseError) {
+      if (primaryError !== void 0) {
+        throw new AggregateError(
+          [primaryError, releaseError],
+          "startup recovery failed and its checkout lease could not be released"
+        );
+      }
+      throw releaseError;
+    }
+  }
+  if (primaryError !== void 0) throw primaryError;
+  return recovered;
 }
 function defaultRequestCooperativeTermination(pid) {
   try {
@@ -31636,13 +31779,31 @@ async function reclaimLocks(locksRoot, isProcessAlive, getProcessStartToken) {
     }
     const contents = await readBoundedRegularFile(lockPath);
     if (contents === null) continue;
-    if (await lockOwnerIsLive(parseLockOwner(contents), isProcessAlive, getProcessStartToken)) continue;
-    const identity = await lstat6(lockPath);
-    if (!identity.isFile() || identity.isSymbolicLink()) {
+    const owner = parseLockOwner(contents);
+    if (owner === null || await lockOwnerIsLive(owner, isProcessAlive, getProcessStartToken)) continue;
+    if (!await lockIsStableRegularFile(lockPath, contents)) {
       throw new RuntimeError("checkout lock identity changed during recovery");
     }
     await rm7(lockPath, { force: false });
   }
+}
+async function lockIsStableRegularFile(lockPath, expected) {
+  const before = await lstat6(lockPath);
+  const current = await readBoundedRegularFile(lockPath);
+  if (current === null) return false;
+  const after = await lstat6(lockPath);
+  return before.isFile() && !before.isSymbolicLink() && after.isFile() && !after.isSymbolicLink() && before.dev === after.dev && before.ino === after.ino && current === expected;
+}
+async function reclaimExactLock(locksRoot, lockKey, isProcessAlive, getProcessStartToken) {
+  const lockPath = path14.join(locksRoot, `${lockKey}.lock`);
+  const contents = await readBoundedRegularFile(lockPath);
+  if (contents === null) return;
+  const owner = parseLockOwner(contents);
+  if (owner === null || await lockOwnerIsLive(owner, isProcessAlive, getProcessStartToken)) return;
+  if (!await lockIsStableRegularFile(lockPath, contents)) {
+    throw new RuntimeError("checkout lock identity changed during recovery");
+  }
+  await rm7(lockPath, { force: false });
 }
 async function lockIsOwnedByLiveProcess(locksRoot, lockKey, isProcessAlive, getProcessStartToken) {
   const contents = await readBoundedRegularFile(path14.join(locksRoot, `${lockKey}.lock`));
@@ -31654,8 +31815,15 @@ async function recoverStaleRuns(dependencies = {}) {
   if (root === null) return { recovered: [] };
   const runsRoot = path14.join(root, "runs");
   const runsIdentity = await plainDirectoryIdentity(runsRoot);
-  if (runsIdentity !== null) await replayInterruptedPrunes(runsRoot);
-  const ps = dependencies.platformServices ?? getPlatformServices();
+  const supplied = dependencies.platformServices;
+  const selected = getPlatformServices();
+  const ps = {
+    os: supplied?.os ?? selected.os,
+    getProcessStartToken: (pid) => (supplied ?? selected).getProcessStartToken(pid),
+    terminateProcessTreeByPid: (pid, token) => (supplied ?? selected).terminateProcessTreeByPid(pid, token),
+    acquireCheckoutLock: (checkout) => supplied && supplied.acquireCheckoutLock ? supplied.acquireCheckoutLock(checkout) : selected.acquireCheckoutLock(checkout)
+  };
+  if (runsIdentity !== null) await replayInterruptedPrunes(runsRoot, ps);
   const isProcessAlive = dependencies.isProcessAlive ?? defaultIsProcessAlive;
   const requestCooperativeTermination = dependencies.requestCooperativeTermination ?? defaultRequestCooperativeTermination;
   const delayMs = dependencies.delayMs ?? defaultDelayMs;
@@ -31673,22 +31841,14 @@ async function recoverStaleRuns(dependencies = {}) {
       const record2 = parseRunStart(runStartText, entry.name);
       const store = new ArtifactStore(entry.name);
       const result = await store.readResult(entry.name);
-      if (result !== null) {
-        validateTerminalResult(result, entry.name);
-        const marker = await store.readPipelineActiveMarker(entry.name);
-        if (marker !== null && !await lockOwnerIsLive(
-          { pid: marker.pid, processToken: marker.processToken },
-          isProcessAlive,
-          (pid) => ps.getProcessStartToken(pid)
-        )) {
-          const commonDir = await validateGitCommonDir(record2.canonicalCommonDir);
-          if (marker.sliced) await archiveInterruptedPipeline(store, result);
-          await cleanupManagedWorktrees(commonDir, root, entry.name, ps);
-          await cleanupTemporarySliceRefs2(commonDir, entry.name, runGit);
-          await store.clearPipelineActiveMarker();
-        }
-        continue;
-      }
+      if (result !== null) validateTerminalResult(result, entry.name);
+      const marker = result === null ? null : await store.readPipelineActiveMarker(entry.name);
+      if (result !== null && marker === null) continue;
+      if (marker !== null && await lockOwnerIsLive(
+        { pid: marker.pid, processToken: marker.processToken },
+        isProcessAlive,
+        (pid) => ps.getProcessStartToken(pid)
+      )) continue;
       if (await lockIsOwnedByLiveProcess(
         locksRoot,
         record2.lockKey,
@@ -31700,7 +31860,7 @@ async function recoverStaleRuns(dependencies = {}) {
   }
   const recovered = [];
   for (const record2 of stale) {
-    await recoverRun(
+    if (await recoverRun(
       record2,
       root,
       ps,
@@ -31708,9 +31868,9 @@ async function recoverStaleRuns(dependencies = {}) {
       requestCooperativeTermination,
       delayMs,
       graceMs,
-      runGit
-    );
-    recovered.push(record2.runId);
+      runGit,
+      locksRoot
+    )) recovered.push(record2.runId);
   }
   await reclaimLocks(
     locksRoot,

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -32053,6 +32053,10 @@ async function truncateCleanupTornTail(filename) {
     }
     const text = await handle.readFile({ encoding: "utf8" });
     if (text === "" || text.endsWith("\n")) return;
+    const settled = await handle.stat();
+    if (Buffer.byteLength(text, "utf8") !== metadata.size || settled.size !== metadata.size || settled.mtimeMs !== metadata.mtimeMs || settled.ctimeMs !== metadata.ctimeMs) {
+      throw new RuntimeError("cleanup journal changed during torn-tail repair");
+    }
     const finalNewline = text.lastIndexOf("\n");
     const completePrefix = finalNewline === -1 ? "" : text.slice(0, finalNewline + 1);
     await handle.truncate(Buffer.byteLength(completePrefix, "utf8"));
@@ -32687,7 +32691,6 @@ async function recoverStaleRuns(dependencies = {}) {
     const runsRoot = path14.join(root, "runs");
     const runsIdentity = await plainDirectoryIdentity(runsRoot);
     if (runsIdentity !== null) await replayInterruptedPrunes(runsRoot, ps);
-    const deferredPruneRunIds = /* @__PURE__ */ new Set();
     const journaledQuarantines = runsIdentity === null ? /* @__PURE__ */ new Set() : (await readRecoveryQuarantineJournal(runsRoot)).runIds;
     const stale = [];
     const recovered = [];
@@ -32703,7 +32706,6 @@ async function recoverStaleRuns(dependencies = {}) {
           }
           continue;
         }
-        if (deferredPruneRunIds.has(entry.name)) continue;
         if (!entry.isDirectory() || entry.isSymbolicLink() || !SAFE_RUN_ID.test(entry.name)) continue;
         try {
           const runDirectory = path14.join(runsRoot, entry.name);

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -30254,27 +30254,95 @@ async function runPipelineWithLease(checkoutPath, spec, deps, ps, borrowedChecko
       if (phase.haltedSliceIndex !== null) {
         const halted = phase.slices.at(-1);
         const reason = `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`;
-        const failedAttempt = await archiveSlicedFailure({
+        if (currentCandidateCommit === baselineCommit) {
+          const failedAttempt = await archiveSlicedFailure({
+            checkoutPath,
+            attempt,
+            failure: "verification-failure",
+            reason,
+            store
+          });
+          authoritySafeToRelease = true;
+          finalAttempt = failedAttempt;
+          const failed = failedResult(
+            failedAttempt,
+            rounds,
+            currentCandidateCommit,
+            reason,
+            "verification-failure",
+            increments,
+            phase.slices,
+            phase.haltedSliceIndex
+          );
+          await store.writePipelineArtifact("pipeline-result", failed);
+          return failed;
+        }
+        const promoted = await promoteFinalCandidate({
           checkoutPath,
           attempt,
-          failure: "verification-failure",
-          reason,
+          initialCandidate: attempt.candidate,
+          baselineCommit,
+          candidateCommit: currentCandidateCommit,
           store
         });
+        if (promoted === null) {
+          const promotionReason = "partial halt candidate could not be promoted from the git object store";
+          const failedAttempt = await archiveSlicedFailure({
+            checkoutPath,
+            attempt,
+            failure: "sandbox-violation",
+            reason: promotionReason,
+            store
+          });
+          authoritySafeToRelease = true;
+          finalAttempt = failedAttempt;
+          const failed = failedResult(
+            failedAttempt,
+            rounds,
+            currentCandidateCommit,
+            promotionReason,
+            "sandbox-violation",
+            increments,
+            phase.slices,
+            phase.haltedSliceIndex
+          );
+          await store.writePipelineArtifact("pipeline-result", failed);
+          return failed;
+        }
+        finalAttempt = promoted.attempt;
+        currentCandidateCommit = promoted.candidateCommit;
         authoritySafeToRelease = true;
-        finalAttempt = failedAttempt;
-        const failed = failedResult(
-          failedAttempt,
-          rounds,
-          currentCandidateCommit,
-          reason,
-          "verification-failure",
+        notePhase("partial halt verification");
+        const verified2 = await verifyCandidate({
+          checkoutPath,
+          spec,
+          deps,
+          attempt: finalAttempt,
+          baselineCommit,
+          candidateCommit: currentCandidateCommit,
+          store,
+          namespace: "final"
+        });
+        await store.writePipelineArtifact("verification", verified2.verification);
+        const haltResult = {
+          runId: attempt.runId,
+          status: "human-decision-required",
+          attempt: finalAttempt,
           increments,
-          phase.slices,
-          phase.haltedSliceIndex
-        );
-        await store.writePipelineArtifact("pipeline-result", failed);
-        return failed;
+          slices: phase.slices,
+          haltedSliceIndex: phase.haltedSliceIndex,
+          rounds,
+          verification: verified2.verification,
+          gate: {
+            decisionReady: false,
+            requiresHumanDecision: true,
+            reasons: [reason]
+          },
+          finalCandidateCommit: currentCandidateCommit,
+          failure: null
+        };
+        await store.writePipelineArtifact("pipeline-result", haltResult);
+        return haltResult;
       }
       frozenTestEvidence = sliceTestEvidence(phase.slices);
     }

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -22186,9 +22186,11 @@ var PosixPlatformServices = class {
   }
   async acquireCheckoutLock(checkout) {
     const { canonical, gitCommonDir: commonDir } = await this.canonicalizePath(checkout);
-    const key = createHash("sha256").update(commonDir ?? canonical).digest("hex");
+    const repositoryIdentity = commonDir ?? canonical;
+    const key = createHash("sha256").update(repositoryIdentity).digest("hex");
     const ownerToken = await this.getProcessStartToken(nodeProcess2.pid);
-    return acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
+    const lock = await acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
+    return { ...lock, repositoryIdentity };
   }
   async createSecureTempDirectory() {
     return fs.mkdtemp(path.join(tmpdir2(), "claude-architect-"));
@@ -22510,9 +22512,11 @@ var WindowsPlatformServices = class {
   }
   async acquireCheckoutLock(checkout) {
     const { canonical, gitCommonDir: commonDir } = await this.canonicalizePath(checkout);
-    const key = createHash2("sha256").update(commonDir ?? canonical).digest("hex");
+    const repositoryIdentity = commonDir ?? canonical;
+    const key = createHash2("sha256").update(repositoryIdentity).digest("hex");
     const ownerToken = await this.getProcessStartToken(nodeProcess3.pid);
-    return acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
+    const lock = await acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
+    return { ...lock, repositoryIdentity };
   }
   async createSecureTempDirectory() {
     return fs2.mkdtemp(path2.join(tmpdir3(), "claude-architect-"));
@@ -27871,10 +27875,7 @@ async function runAttempt(checkoutPath, spec, deps) {
   const store = new ArtifactStore(runId);
   const canonical = await ps.canonicalizePath(checkoutPath);
   const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
-  if (deps.borrowedCheckoutLease !== void 0 && deps.borrowedCheckoutLease.repositoryIdentity !== repositoryIdentity) {
-    throw new RuntimeError("borrowed checkout lease repository identity mismatch");
-  }
-  let lock = deps.borrowedCheckoutLease?.lock ?? null;
+  let lock = deps.borrowedCheckoutLease ?? null;
   let ownedLock = null;
   let worktree = null;
   let tempHome = null;
@@ -27884,6 +27885,9 @@ async function runAttempt(checkoutPath, spec, deps) {
     if (lock === null) {
       ownedLock = await ps.acquireCheckoutLock(canonical.canonical);
       lock = ownedLock;
+    }
+    if (lock.repositoryIdentity !== repositoryIdentity) {
+      throw new RuntimeError("borrowed checkout lease repository identity mismatch");
     }
     const preconditions = await checkPreconditions(canonical.canonical, {
       writeAllowlist: spec.writeAllowlist
@@ -29862,10 +29866,6 @@ async function runPipeline(checkoutPath, spec, deps) {
   const ps = deps.ps ?? getPlatformServices();
   const canonical = await ps.canonicalizePath(checkoutPath);
   const lock = await ps.acquireCheckoutLock(canonical.canonical);
-  const borrowedCheckoutLease = {
-    lock,
-    repositoryIdentity: canonical.gitCommonDir ?? canonical.canonical
-  };
   let primaryError;
   let hasPrimaryError = false;
   try {
@@ -29874,7 +29874,7 @@ async function runPipeline(checkoutPath, spec, deps) {
       spec,
       deps,
       ps,
-      borrowedCheckoutLease
+      lock
     );
   } catch (error2) {
     primaryError = error2;

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -22550,6 +22550,9 @@ function resolveReviewConfig(spec) {
 function resolveImplementationConfig(spec) {
   return spec.implementation ?? DEFAULT_IMPLEMENTATION_CONFIG;
 }
+function resolveSlices(spec) {
+  return spec.slices ?? [];
+}
 var RUNTIME_MAX_TIMEOUT_MS = 18e5;
 var RUNTIME_MIN_EDIT_TIMEOUT_MS = 6e5;
 
@@ -26052,9 +26055,10 @@ async function projectVerify(args) {
   const now = args.now ?? Date.now;
   const anchorPrefix = "refs/claude-architect/candidates/";
   const artifactRunId = args.artifact.anchorRef.startsWith(anchorPrefix) ? args.artifact.anchorRef.slice(anchorPrefix.length) : args.artifact.candidateCommitOid;
+  const verificationId = args.runId ?? args.verificationId?.() ?? artifactRunId;
   const manager = new WorktreeManager(
     args.repoRoot,
-    `verify-${args.runId ?? artifactRunId}`,
+    `verify-${verificationId}`,
     ps
   );
   const materialized = await manager.create(args.artifact.candidateCommitOid);
@@ -28431,6 +28435,124 @@ function evaluateGates(input) {
   return { decisionReady: reasons.length === 0, requiresHumanDecision, reasons };
 }
 
+// src/pipeline/wayfinder.ts
+function routeSlice(input) {
+  if (input.hardBlocker) {
+    return { route: "halt", reasons: ["unrecoverable blocker"] };
+  }
+  const reasons = [];
+  const { verification } = input;
+  if (verification === null) {
+    return { route: "halt", reasons: ["verification report missing (fail closed)"] };
+  }
+  if (!verification.pass) {
+    reasons.push("slice verification failed");
+  }
+  if (verification.testsDeleted > 0) {
+    reasons.push(`${verification.testsDeleted} test(s) deleted`);
+  }
+  if (verification.testsSkipped > 0) {
+    reasons.push(`${verification.testsSkipped} test(s) newly skipped`);
+  }
+  if (!verification.workspaceClean) {
+    reasons.push("verify worktree dirty after checks");
+  }
+  if (verification.scopeViolations.length > 0) {
+    reasons.push(`out-of-scope diff: ${verification.scopeViolations.join(", ")}`);
+  }
+  if (input.perSliceReview !== null && input.perSliceReview.findings.some(
+    (finding) => finding.severity === "blocker" || finding.severity === "major"
+  )) {
+    reasons.push("per-slice review found blocking findings");
+  }
+  if (reasons.length === 0) {
+    return { route: "advance", reasons };
+  }
+  if (input.roundsUsed < input.maxRounds) {
+    return { route: "repair", reasons };
+  }
+  return { route: "halt", reasons };
+}
+
+// src/pipeline/slice-runner.ts
+async function runSlicePhase(slices, startCommit, deps) {
+  let currentCommit = startCommit;
+  const results = [];
+  for (const [offset, slice] of slices.entries()) {
+    const index = offset + 1;
+    let roundsUsed = 0;
+    const attempts = [];
+    while (true) {
+      const sourceAttempt = index === 1 && roundsUsed === 0 && deps.initialAttempt !== void 0 ? deps.initialAttempt : await deps.runSlice(slice, index, currentCommit, roundsUsed);
+      const attempt = structuredClone(sourceAttempt);
+      const perSliceReview = attempt.perSliceReview ?? null;
+      const route2 = routeSlice({
+        verification: attempt.verification,
+        perSliceReview,
+        roundsUsed,
+        maxRounds: deps.maxRounds,
+        hardBlocker: attempt.hardBlocker ?? false
+      });
+      const evidence = {
+        sliceIndex: index,
+        attempt: roundsUsed,
+        candidateCommit: attempt.candidateCommit,
+        verification: attempt.verification,
+        perSliceReview,
+        route: route2.route,
+        reasons: [...route2.reasons],
+        roleLogRefs: [...attempt.roleLogRefs ?? []]
+      };
+      if (deps.onAttempt) {
+        await deps.onAttempt(structuredClone(evidence));
+      }
+      attempts.push(evidence);
+      const pipelineSlice = {
+        index,
+        objective: slice.objective,
+        route: route2.route,
+        candidateCommit: attempt.candidateCommit,
+        roundsUsed,
+        verification: attempt.verification,
+        perSliceReview,
+        reasons: [...route2.reasons],
+        attempts: attempts.map((entry) => ({
+          ...entry,
+          reasons: [...entry.reasons],
+          roleLogRefs: [...entry.roleLogRefs]
+        })),
+        roleLogRefs: attempts.flatMap((entry) => entry.roleLogRefs)
+      };
+      if (route2.route === "advance") {
+        results.push(pipelineSlice);
+        if (deps.onSlice) {
+          await deps.onSlice(structuredClone(pipelineSlice));
+        }
+        currentCommit = attempt.candidateCommit;
+        break;
+      }
+      if (route2.route === "repair") {
+        roundsUsed += 1;
+        continue;
+      }
+      results.push(pipelineSlice);
+      if (deps.onSlice) {
+        await deps.onSlice(structuredClone(pipelineSlice));
+      }
+      return {
+        slices: results,
+        finalCandidateCommit: currentCommit,
+        haltedSliceIndex: index
+      };
+    }
+  }
+  return {
+    slices: results,
+    finalCandidateCommit: currentCommit,
+    haltedSliceIndex: null
+  };
+}
+
 // src/pipeline/role-runner.ts
 import { rm as rm6 } from "node:fs/promises";
 
@@ -28964,6 +29086,11 @@ var IGNORED_STRUCTURAL_FAILURES = /* @__PURE__ */ new Set([
   "artifact-divergence",
   "base-changed"
 ]);
+function scopeSpecToSlice(spec, slice) {
+  const scoped = structuredClone({ ...spec, ...slice });
+  delete scoped.slices;
+  return scoped;
+}
 function gitFailure5(action, result) {
   const diagnostic = (result.stderr || result.stdout).trim().slice(0, 2e3);
   return new RuntimeError(`${action} failed${diagnostic ? `: ${diagnostic}` : ""}`);
@@ -29109,6 +29236,59 @@ function testEvidence(attempt) {
     exitCode: outcome.exitCode,
     timedOut: outcome.timedOut
   })));
+}
+function attemptLogRefs(attempt) {
+  return [.../* @__PURE__ */ new Set([
+    attempt.logsRef,
+    ...attempt.executedVerification.flatMap((outcome) => [outcome.stdoutRef, outcome.stderrRef])
+  ])];
+}
+function verificationTestEvidence(verification) {
+  return {
+    pass: verification.pass,
+    commandResults: verification.commandResults.map((command) => ({ ...command })),
+    workspaceClean: verification.workspaceClean,
+    testsDeleted: verification.testsDeleted,
+    testsSkipped: verification.testsSkipped,
+    scopeViolations: [...verification.scopeViolations]
+  };
+}
+function sliceTestEvidence(slices) {
+  return JSON.stringify(slices.map((slice) => ({
+    sliceIndex: slice.index,
+    verification: slice.verification === null ? null : verificationTestEvidence(slice.verification),
+    attempts: slice.attempts.map((attempt) => ({
+      attempt: attempt.attempt,
+      verification: attempt.verification === null ? null : verificationTestEvidence(attempt.verification)
+    }))
+  })));
+}
+var SliceExecutionError = class extends RuntimeError {
+  constructor(message, failure2) {
+    super(message);
+    this.failure = failure2;
+    this.name = "SliceExecutionError";
+  }
+};
+async function withManagedWorktree(args) {
+  const worktree = await args.manager.create(args.commit);
+  let primaryError;
+  try {
+    return await args.run(worktree.path);
+  } catch (error2) {
+    primaryError = error2;
+    throw error2;
+  } finally {
+    try {
+      await worktree.cleanup();
+    } catch (cleanupError) {
+      if (primaryError === void 0) throw cleanupError;
+      throw new AggregateError(
+        [primaryError, cleanupError],
+        args.cleanupFailureMessage
+      );
+    }
+  }
 }
 function escapeRegex4(character) {
   return /[\\^$.*+?()[\]{}|]/.test(character) ? `\\${character}` : character;
@@ -29261,6 +29441,54 @@ async function runReviews(args) {
     throw new Error("unreachable invalid review state");
   }
   return { ok: false, failedRoleLogRef: failed.initialLogRef, roleLogRefs };
+}
+async function runSliceReview(args) {
+  const ps = args.deps.ps ?? getPlatformServices();
+  return withManagedWorktree({
+    manager: new WorktreeManager(
+      args.checkoutPath,
+      `${args.runId}-${args.namespace}-review`,
+      ps
+    ),
+    commit: args.candidateCommit,
+    cleanupFailureMessage: "slice review failed and its worktree could not be cleaned up",
+    run: async (worktreePath) => {
+      const diffText = await checkedGit4(worktreePath, [
+        "diff",
+        `${args.baselineCommit}..${args.candidateCommit}`
+      ]);
+      const reviewRun = await runReviews({
+        reviewers: args.reviewers,
+        spec: args.spec,
+        pkg: {
+          spec: args.spec,
+          baselineCommit: args.baselineCommit,
+          candidateCommit: args.candidateCommit,
+          candidateDiff: diffText,
+          testEvidence: JSON.stringify(verificationTestEvidence(args.verification))
+        },
+        worktreePath,
+        deps: args.deps,
+        runId: args.runId,
+        round: 1,
+        store: args.store,
+        logNameNamespace: args.namespace
+      });
+      if (!reviewRun.ok) {
+        throw new SliceExecutionError(
+          `slice review did not produce valid structured output (see ${reviewRun.failedRoleLogRef})`,
+          "producer-failure"
+        );
+      }
+      return {
+        review: consolidate(reviewRun.reviews.map((review) => ({
+          reviewer: review.reviewer,
+          report: review.report
+        }))),
+        roleLogRefs: reviewRun.roleLogRefs
+      };
+    }
+  });
 }
 async function runFix(args) {
   const outcome = await runStructuredRole({
@@ -29497,6 +29725,8 @@ async function verifyCandidate(args) {
 }
 async function runPipeline(checkoutPath, spec, deps) {
   const runAttemptFn = deps.runAttempt ?? runAttempt;
+  const slices = resolveSlices(spec);
+  const initialSpec = slices.length === 0 ? spec : scopeSpecToSlice(spec, slices[0]);
   const notePhase = (phase) => {
     try {
       deps.onPhase?.(phase);
@@ -29505,7 +29735,7 @@ async function runPipeline(checkoutPath, spec, deps) {
   };
   let runStart;
   const inheritedOnRunStart = deps.onRunStart;
-  const attempt = await runAttemptFn(checkoutPath, spec, {
+  const attempt = await runAttemptFn(checkoutPath, initialSpec, {
     ...deps,
     onRunStart(context) {
       runStart = context;
@@ -29531,18 +29761,213 @@ async function runPipeline(checkoutPath, spec, deps) {
   await store.writePipelineActiveMarker(activeOwner);
   let pipelinePrimaryError;
   try {
-    const { reviewers, maxRounds } = resolveReviewConfig(spec);
-    const { maxIncrements } = resolveImplementationConfig(spec);
+    const reviewConfig = resolveReviewConfig(spec);
+    const { reviewers, maxRounds } = reviewConfig;
+    const maxIncrements = slices.length === 0 ? resolveImplementationConfig(spec).maxIncrements : 1;
     let finalAttempt = attempt;
     const increments = [];
     let incrementOutcome;
     const rounds = [];
     const baselineCommit = attempt.candidate.baseCommitOid;
     let currentCandidateCommit = attempt.candidate.candidateCommitOid;
-    const frozenTestEvidence = testEvidence(attempt);
+    let frozenTestEvidence = testEvidence(attempt);
+    let pipelineSlices = [];
+    if (slices.length > 0) {
+      const initialNamespace = "slice-1-attempt-0";
+      const initialVerification = await verifyCandidate({
+        checkoutPath,
+        spec: initialSpec,
+        deps,
+        attempt,
+        baselineCommit,
+        candidateCommit: currentCandidateCommit,
+        store,
+        namespace: initialNamespace
+      });
+      let initialPerSliceReview = null;
+      const initialRoleLogRefs = attemptLogRefs(attempt);
+      if (reviewConfig.perSlice === true) {
+        const reviewed = await runSliceReview({
+          checkoutPath,
+          spec: initialSpec,
+          deps,
+          runId: attempt.runId,
+          baselineCommit,
+          candidateCommit: currentCandidateCommit,
+          namespace: initialNamespace,
+          reviewers,
+          verification: initialVerification.verification,
+          store
+        });
+        initialPerSliceReview = reviewed.review;
+        initialRoleLogRefs.push(...reviewed.roleLogRefs);
+      }
+      const completedSlices = [];
+      let phase;
+      try {
+        phase = await runSlicePhase(slices, baselineCommit, {
+          maxRounds,
+          initialAttempt: {
+            candidateCommit: currentCandidateCommit,
+            verification: initialVerification.verification,
+            perSliceReview: initialPerSliceReview,
+            roleLogRefs: initialRoleLogRefs
+          },
+          runSlice: async (slice, index, base, sliceAttempt) => {
+            const namespace = `slice-${index}-attempt-${sliceAttempt}`;
+            const scopedSpec = scopeSpecToSlice(spec, slice);
+            return withManagedWorktree({
+              manager: new WorktreeManager(
+                checkoutPath,
+                `${attempt.runId}-${namespace}`,
+                ps
+              ),
+              commit: base,
+              cleanupFailureMessage: "slice implementation failed and its worktree could not be cleaned up",
+              run: async (worktreePath) => {
+                let gitObjectAccess2;
+                try {
+                  gitObjectAccess2 = await resolveLinkedWorktreeWritableRoots(worktreePath);
+                } catch {
+                  throw new SliceExecutionError(
+                    "slice implementer git object isolation could not be established",
+                    "sandbox-violation"
+                  );
+                }
+                const incrementRun = await runIncrement({
+                  spec: scopedSpec,
+                  pkg: {
+                    spec: scopedSpec,
+                    baselineCommit: base,
+                    candidateCommit: base,
+                    candidateDiff: "",
+                    testEvidence: completedSlices.length === 0 ? testEvidence(attempt) : sliceTestEvidence(completedSlices)
+                  },
+                  worktreePath,
+                  deps,
+                  runId: attempt.runId,
+                  increment: sliceAttempt + 1,
+                  store,
+                  gitObjectAccess: gitObjectAccess2,
+                  ...runStart === void 0 ? {} : { runStart },
+                  logNameNamespace: namespace
+                });
+                if (!incrementRun.ok) {
+                  throw new SliceExecutionError(
+                    `slice implementer did not produce valid structured output (see ${incrementRun.failedRoleLogRef})`,
+                    incrementRun.failure
+                  );
+                }
+                const candidateCommit = incrementRun.report.candidateCommit;
+                const provenanceFailure = await validateCandidateProvenance({
+                  worktreePath,
+                  previousCandidateCommit: base,
+                  candidateCommit,
+                  gitObjectAccess: gitObjectAccess2
+                });
+                if (provenanceFailure !== null) {
+                  throw new SliceExecutionError(
+                    provenanceFailure.reason,
+                    provenanceFailure.failure
+                  );
+                }
+                if (candidateCommit !== base) {
+                  try {
+                    await importPromotedObjects({
+                      checkoutPath,
+                      baselineCommit: base,
+                      promotedCommit: candidateCommit,
+                      access: gitObjectAccess2
+                    });
+                  } catch {
+                    throw new SliceExecutionError(
+                      "slice candidate objects could not be imported into the shared git object store",
+                      "sandbox-violation"
+                    );
+                  }
+                }
+                const verified2 = await verifyCandidate({
+                  checkoutPath,
+                  spec: scopedSpec,
+                  deps,
+                  attempt,
+                  baselineCommit: base,
+                  candidateCommit,
+                  store,
+                  namespace
+                });
+                let perSliceReview = null;
+                const roleLogRefs = [...incrementRun.roleLogRefs];
+                if (reviewConfig.perSlice === true) {
+                  const reviewed = await runSliceReview({
+                    checkoutPath,
+                    spec: scopedSpec,
+                    deps,
+                    runId: attempt.runId,
+                    baselineCommit: base,
+                    candidateCommit,
+                    namespace,
+                    reviewers,
+                    verification: verified2.verification,
+                    store
+                  });
+                  perSliceReview = reviewed.review;
+                  roleLogRefs.push(...reviewed.roleLogRefs);
+                }
+                return {
+                  candidateCommit,
+                  verification: verified2.verification,
+                  perSliceReview,
+                  roleLogRefs
+                };
+              }
+            });
+          },
+          onAttempt: (evidence) => store.writePipelineArtifact(
+            `slice-${evidence.sliceIndex}-attempt-${evidence.attempt}`,
+            evidence
+          ),
+          onSlice: async (slice) => {
+            await store.writePipelineArtifact(`slice-${slice.index}`, slice);
+            completedSlices.push(structuredClone(slice));
+          }
+        });
+      } catch (error2) {
+        if (!(error2 instanceof SliceExecutionError)) throw error2;
+        const failed = failedResult(
+          attempt,
+          rounds,
+          completedSlices.at(-1)?.candidateCommit ?? baselineCommit,
+          error2.message,
+          error2.failure,
+          increments,
+          completedSlices
+        );
+        await store.writePipelineArtifact("pipeline-result", failed);
+        return failed;
+      }
+      pipelineSlices = phase.slices;
+      currentCandidateCommit = phase.finalCandidateCommit;
+      if (phase.haltedSliceIndex !== null) {
+        const halted = phase.slices.at(-1);
+        const failed = failedResult(
+          attempt,
+          rounds,
+          currentCandidateCommit,
+          `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`,
+          "verification-failure",
+          increments,
+          phase.slices,
+          phase.haltedSliceIndex
+        );
+        await store.writePipelineArtifact("pipeline-result", failed);
+        return failed;
+      }
+      frozenTestEvidence = sliceTestEvidence(phase.slices);
+    }
     const candidateWorktree = await new WorktreeManager(
       checkoutPath,
-      `${attempt.runId}-pipeline`,
+      slices.length === 0 ? `${attempt.runId}-pipeline` : `${attempt.runId}-composed-review`,
       ps
     ).create(currentCandidateCommit);
     let gitObjectAccess = null;
@@ -29558,7 +29983,8 @@ async function runPipeline(checkoutPath, spec, deps) {
             currentCandidateCommit,
             "increment git object isolation could not be established",
             "sandbox-violation",
-            increments
+            increments,
+            pipelineSlices
           );
         }
         try {
@@ -29594,7 +30020,8 @@ async function runPipeline(checkoutPath, spec, deps) {
                 currentCandidateCommit,
                 `increment phase did not produce valid structured output (see ${incrementRun.failedRoleLogRef})`,
                 incrementRun.failure,
-                increments
+                increments,
+                pipelineSlices
               );
             }
             const report = redactRecord(incrementRun.report);
@@ -29612,7 +30039,8 @@ async function runPipeline(checkoutPath, spec, deps) {
                 currentCandidateCommit,
                 provenanceFailure.reason,
                 provenanceFailure.failure,
-                increments
+                increments,
+                pipelineSlices
               );
             }
             const privateObjects = privateObjectReadOptions(gitObjectAccess);
@@ -29644,7 +30072,8 @@ async function runPipeline(checkoutPath, spec, deps) {
                   currentCandidateCommit,
                   "increment objects could not be imported into the shared git object store",
                   "sandbox-violation",
-                  increments
+                  increments,
+                  pipelineSlices
                 );
               }
             }
@@ -29675,7 +30104,8 @@ async function runPipeline(checkoutPath, spec, deps) {
             currentCandidateCommit,
             "increment phase failed unexpectedly",
             "producer-failure",
-            increments
+            increments,
+            pipelineSlices
           );
         }
       }
@@ -29709,7 +30139,8 @@ async function runPipeline(checkoutPath, spec, deps) {
             currentCandidateCommit,
             `review phase did not produce valid structured output (see ${reviewRun.failedRoleLogRef})`,
             "producer-failure",
-            increments
+            increments,
+            pipelineSlices
           );
         }
         const reviews = reviewRun.reviews.map((review) => ({
@@ -29739,7 +30170,8 @@ async function runPipeline(checkoutPath, spec, deps) {
             currentCandidateCommit,
             "fixer git object isolation could not be established",
             "sandbox-violation",
-            increments
+            increments,
+            pipelineSlices
           );
         }
         notePhase(`round ${round}: applying fixes`);
@@ -29761,7 +30193,8 @@ async function runPipeline(checkoutPath, spec, deps) {
             currentCandidateCommit,
             `fix phase did not produce valid structured output (see ${fixRun.failedRoleLogRef})`,
             fixRun.failure,
-            increments
+            increments,
+            pipelineSlices
           );
         }
         const { fix } = fixRun;
@@ -29779,7 +30212,8 @@ async function runPipeline(checkoutPath, spec, deps) {
             currentCandidateCommit,
             provenanceFailure.reason,
             provenanceFailure.failure,
-            increments
+            increments,
+            pipelineSlices
           );
         }
         currentCandidateCommit = fix.candidateCommit;
@@ -29792,14 +30226,15 @@ async function runPipeline(checkoutPath, spec, deps) {
         });
       }
       if (currentCandidateCommit !== attempt.candidate.candidateCommitOid) {
-        if (gitObjectAccess === null) {
+        if (gitObjectAccess === null && slices.length === 0) {
           return failedResult(
             attempt,
             rounds,
             currentCandidateCommit,
             "fixer git object isolation state is missing during promotion",
             "sandbox-violation",
-            increments
+            increments,
+            pipelineSlices
           );
         }
         const promoted = await promoteFinalCandidate({
@@ -29809,16 +30244,17 @@ async function runPipeline(checkoutPath, spec, deps) {
           baselineCommit,
           candidateCommit: currentCandidateCommit,
           store,
-          privateObjectAccess: gitObjectAccess
+          ...gitObjectAccess === null ? {} : { privateObjectAccess: gitObjectAccess }
         });
         if (promoted === null) {
           return failedResult(
             attempt,
             rounds,
             currentCandidateCommit,
-            "fixer objects could not be imported into the shared git object store",
+            slices.length === 0 ? "fixer objects could not be imported into the shared git object store" : "sliced candidate could not be promoted from the shared git object store",
             "sandbox-violation",
-            increments
+            increments,
+            pipelineSlices
           );
         }
         finalAttempt = promoted.attempt;
@@ -29846,7 +30282,8 @@ async function runPipeline(checkoutPath, spec, deps) {
       attempt: finalAttempt,
       baselineCommit,
       candidateCommit: currentCandidateCommit,
-      store
+      store,
+      ...slices.length === 0 ? {} : { namespace: "final" }
     });
     await store.writePipelineArtifact("verification", verified.verification);
     const lastRound = rounds.at(-1);
@@ -29867,7 +30304,7 @@ async function runPipeline(checkoutPath, spec, deps) {
       status: gate.decisionReady ? "decision-ready" : "human-decision-required",
       attempt: finalAttempt,
       increments,
-      slices: [],
+      slices: pipelineSlices,
       haltedSliceIndex: null,
       rounds,
       verification: verified.verification,

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -27887,7 +27887,8 @@ async function runAttempt(checkoutPath, spec, deps) {
       lock = ownedLock;
     }
     if (lock.repositoryIdentity !== repositoryIdentity) {
-      throw new RuntimeError("borrowed checkout lease repository identity mismatch");
+      const ownership = ownedLock === null ? "borrowed" : "owned";
+      throw new RuntimeError(`${ownership} checkout lease repository identity mismatch`);
     }
     const preconditions = await checkPreconditions(canonical.canonical, {
       writeAllowlist: spec.writeAllowlist

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -21930,7 +21930,7 @@ var StdioServerTransport = class {
 var PROTOCOL_VERSION = "1.3.0";
 var DELEGATION_SPEC_VERSION = "1";
 var ATTEMPT_RESULT_VERSION = "1";
-var RUNTIME_VERSION = "0.20.0";
+var RUNTIME_VERSION = "0.21.0";
 
 // src/platform/posix-platform-services.ts
 import { spawn, execFile } from "node:child_process";

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -24486,15 +24486,23 @@ function statusMatchesArtifact(output, changedPaths) {
   return changedPaths.every((change) => actual.get(change.path) === (change.changeType === "added" ? "A" : change.changeType === "deleted" ? "D" : "M"));
 }
 async function applyCandidateTree(args) {
-  const ps = getPlatformServices();
-  const { canonical } = await ps.canonicalizePath(args.repoRoot);
-  const lock = await ps.acquireCheckoutLock(canonical);
+  const ps = args.platformServices ?? getPlatformServices();
+  const canonicalPath = await ps.canonicalizePath(args.repoRoot);
+  const { canonical } = canonicalPath;
+  const repositoryIdentity = canonicalPath.gitCommonDir ?? canonicalPath.canonical;
+  let ownedLock = null;
+  const lock = args.borrowedCheckoutLock ?? await ps.acquireCheckoutLock(canonical);
+  if (args.borrowedCheckoutLock === void 0) ownedLock = lock;
   const terminal = { result: null };
   const finish = (result) => {
     terminal.result = result;
     return result;
   };
   try {
+    if (lock.repositoryIdentity !== repositoryIdentity) {
+      const ownership = ownedLock === null ? "borrowed" : "owned";
+      throw new RuntimeError(`${ownership} checkout lease repository identity mismatch`);
+    }
     const preconditions = await checkPreconditions(canonical);
     if (!preconditions.ok) return finish(aborted2(`precondition-failed:${preconditions.reason}`));
     if (preconditions.baseCommitOid !== args.artifact.baseCommitOid) {
@@ -24577,11 +24585,13 @@ async function applyCandidateTree(args) {
     }
     return finish({ integration: "applied", detail: "candidate tree applied" });
   } finally {
-    try {
-      await lock.release();
-    } catch (error2) {
-      if (terminal.result === null) throw error2;
-      terminal.result.detail = `${terminal.result.detail}; checkout lock release failed`;
+    if (ownedLock !== null) {
+      try {
+        await ownedLock.release();
+      } catch (error2) {
+        if (terminal.result === null) throw error2;
+        terminal.result.detail = `${terminal.result.detail}; checkout lock release failed`;
+      }
     }
   }
 }
@@ -30737,8 +30747,20 @@ function storeFor(runId, deps) {
 function runtimeError(message, error2) {
   return new RuntimeError(message, { toolError: error2 });
 }
+var LifecycleLockReleaseError = class extends AggregateError {
+  constructor(primaryError, releaseError) {
+    const primaryMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
+    super(
+      [primaryError, releaseError],
+      `${primaryMessage}; checkout lock release failed`
+    );
+    this.primaryError = primaryError;
+    this.name = "LifecycleLockReleaseError";
+  }
+};
 function errorResult(error2) {
-  const code = error2 instanceof RuntimeError && typeof error2.detail?.toolError === "string" ? error2.detail.toolError : "runtime-error";
+  const classified = error2 instanceof LifecycleLockReleaseError ? error2.primaryError : error2;
+  const code = classified instanceof RuntimeError && typeof classified.detail?.toolError === "string" ? classified.detail.toolError : "runtime-error";
   const diagnostic = error2 instanceof Error ? error2.message : String(error2);
   return { ok: false, error: code, diagnostic: redact(diagnostic) };
 }
@@ -30795,14 +30817,46 @@ function requireMatchingRepository(run, callerKey) {
     );
   }
 }
-async function withCurrentArchivedRun(checkoutPath, runId, deps, fn) {
-  const canonical = await services2(deps).canonicalizePath(checkoutPath);
+async function withCurrentArchivedRun(checkoutPath, runId, deps, fn, preserveResultOnReleaseFailure) {
+  const ps = services2(deps);
+  const canonical = await ps.canonicalizePath(checkoutPath);
   const callerKey = canonical.gitCommonDir ?? canonical.canonical;
   return withRepoLock(callerKey, async () => {
-    const run = await loadArchivedRun(runId, deps);
-    requireMatchingRepository(run, callerKey);
-    return fn(run);
+    const lock = await ps.acquireCheckoutLock(canonical.canonical);
+    let action;
+    try {
+      if (lock.repositoryIdentity !== callerKey) {
+        throw runtimeError(
+          "supplied checkout repository identity changed before checkout lease acquisition",
+          "run-checkout-mismatch"
+        );
+      }
+      const run = await loadArchivedRun(runId, deps);
+      requireMatchingRepository(run, lock.repositoryIdentity);
+      action = { ok: true, result: await fn(run, lock, ps) };
+    } catch (error2) {
+      action = { ok: false, error: error2 };
+    }
+    try {
+      await lock.release();
+    } catch (releaseError) {
+      if (!action.ok) throw new LifecycleLockReleaseError(action.error, releaseError);
+      if (preserveResultOnReleaseFailure !== void 0) {
+        return preserveResultOnReleaseFailure(action.result);
+      }
+      throw releaseError;
+    }
+    if (!action.ok) throw action.error;
+    return action.result;
   });
+}
+async function requireInactivePipeline(run, runId) {
+  if (await run.store.readPipelineActiveMarker(runId) !== null) {
+    throw runtimeError(
+      "the delegation pipeline for this run is still active",
+      "pipeline-active"
+    );
+  }
 }
 function schemaCompatibility(input) {
   if (isRecord4(input) && input.specVersion !== void 0 && input.specVersion !== DELEGATION_SPEC_VERSION) {
@@ -30921,6 +30975,7 @@ async function handleDelegatePipeline(checkoutPath, input, deps = {}) {
 async function handleReviewCandidate(checkoutPath, runId, deps = {}) {
   try {
     return await withCurrentArchivedRun(checkoutPath, runId, deps, async (run) => {
+      await requireInactivePipeline(run, runId);
       const candidate = requireCandidate(run);
       const git2 = deps.git ?? git;
       const anchor = await git2(run.repoRoot, [
@@ -30967,38 +31022,27 @@ async function handleReviewCandidate(checkoutPath, runId, deps = {}) {
 async function handleDecideCandidate(checkoutPath, runId, decision, deps = {}) {
   try {
     return await withCurrentArchivedRun(checkoutPath, runId, deps, async (run) => {
-      if (await run.store.readPipelineActiveMarker(runId) !== null) {
-        throw runtimeError(
-          "the delegation pipeline for this run is still active",
-          "pipeline-active"
-        );
-      }
+      await requireInactivePipeline(run, runId);
       if (decision === "accepted") requireVerifiedCandidate(run);
-      const ps = services2(deps);
-      const lock = await ps.acquireCheckoutLock(run.repoRoot);
-      try {
-        const record2 = {
-          decision,
-          recordedAt: (deps.now ?? (() => /* @__PURE__ */ new Date()))().toISOString()
-        };
-        await run.store.writeDecision(record2);
-        if (decision === "rejected" && run.result.candidate !== null) {
-          const candidate = run.result.candidate;
-          const deleted = await (deps.git ?? git)(run.repoRoot, [
-            "update-ref",
-            "--no-deref",
-            "-d",
-            candidate.anchorRef,
-            candidate.candidateCommitOid
-          ]);
-          if (deleted.exitCode !== 0) {
-            throw runtimeError("failed to delete rejected candidate anchor", "anchor-delete-failed");
-          }
+      const record2 = {
+        decision,
+        recordedAt: (deps.now ?? (() => /* @__PURE__ */ new Date()))().toISOString()
+      };
+      await run.store.writeDecision(record2);
+      if (decision === "rejected" && run.result.candidate !== null) {
+        const candidate = run.result.candidate;
+        const deleted = await (deps.git ?? git)(run.repoRoot, [
+          "update-ref",
+          "--no-deref",
+          "-d",
+          candidate.anchorRef,
+          candidate.candidateCommitOid
+        ]);
+        if (deleted.exitCode !== 0) {
+          throw runtimeError("failed to delete rejected candidate anchor", "anchor-delete-failed");
         }
-        return { recorded: true };
-      } finally {
-        await lock.release();
       }
+      return { recorded: true };
     });
   } catch (error2) {
     return errorResult(error2);
@@ -31006,13 +31050,8 @@ async function handleDecideCandidate(checkoutPath, runId, decision, deps = {}) {
 }
 async function handleIntegrateCandidate(checkoutPath, runId, expectedArtifactHash, deps = {}) {
   try {
-    return await withCurrentArchivedRun(checkoutPath, runId, deps, async (run) => {
-      if (await run.store.readPipelineActiveMarker(runId) !== null) {
-        throw runtimeError(
-          "the delegation pipeline for this run is still active",
-          "pipeline-active"
-        );
-      }
+    return await withCurrentArchivedRun(checkoutPath, runId, deps, async (run, lock, ps) => {
+      await requireInactivePipeline(run, runId);
       const decision = await run.store.readDecision(runId);
       if (decision?.decision !== "accepted") {
         return { integration: "aborted", detail: "no-accepted-decision" };
@@ -31020,9 +31059,14 @@ async function handleIntegrateCandidate(checkoutPath, runId, expectedArtifactHas
       return (deps.applyCandidateTree ?? applyCandidateTree)({
         repoRoot: run.repoRoot,
         artifact: requireVerifiedCandidate(run),
-        expectedArtifactHash
+        expectedArtifactHash,
+        borrowedCheckoutLock: lock,
+        platformServices: ps
       });
-    });
+    }, (result) => ({
+      ...result,
+      detail: `${result.detail}; checkout lock release failed`
+    }));
   } catch (error2) {
     return errorResult(error2);
   }

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -30744,15 +30744,22 @@ function requireVerifiedCandidate(run) {
   }
   return requireCandidate(run);
 }
-async function requireMatchingCheckout(run, checkoutPath, deps) {
-  const canonical = await services2(deps).canonicalizePath(checkoutPath);
-  const callerKey = canonical.gitCommonDir ?? canonical.canonical;
+function requireMatchingRepository(run, callerKey) {
   if (callerKey !== run.lockKey) {
     throw runtimeError(
       "candidate run belongs to a different repository than the supplied checkoutPath",
       "run-checkout-mismatch"
     );
   }
+}
+async function withCurrentArchivedRun(checkoutPath, runId, deps, fn) {
+  const canonical = await services2(deps).canonicalizePath(checkoutPath);
+  const callerKey = canonical.gitCommonDir ?? canonical.canonical;
+  return withRepoLock(callerKey, async () => {
+    const run = await loadArchivedRun(runId, deps);
+    requireMatchingRepository(run, callerKey);
+    return fn(run);
+  });
 }
 function schemaCompatibility(input) {
   if (isRecord4(input) && input.specVersion !== void 0 && input.specVersion !== DELEGATION_SPEC_VERSION) {
@@ -30870,9 +30877,7 @@ async function handleDelegatePipeline(checkoutPath, input, deps = {}) {
 }
 async function handleReviewCandidate(checkoutPath, runId, deps = {}) {
   try {
-    const run = await loadArchivedRun(runId, deps);
-    await requireMatchingCheckout(run, checkoutPath, deps);
-    return await withRepoLock(run.lockKey, async () => {
+    return await withCurrentArchivedRun(checkoutPath, runId, deps, async (run) => {
       const candidate = requireCandidate(run);
       const git2 = deps.git ?? git;
       const anchor = await git2(run.repoRoot, [
@@ -30918,9 +30923,7 @@ async function handleReviewCandidate(checkoutPath, runId, deps = {}) {
 }
 async function handleDecideCandidate(checkoutPath, runId, decision, deps = {}) {
   try {
-    const run = await loadArchivedRun(runId, deps);
-    await requireMatchingCheckout(run, checkoutPath, deps);
-    return await withRepoLock(run.lockKey, async () => {
+    return await withCurrentArchivedRun(checkoutPath, runId, deps, async (run) => {
       if (await run.store.readPipelineActiveMarker(runId) !== null) {
         throw runtimeError(
           "the delegation pipeline for this run is still active",
@@ -30960,9 +30963,7 @@ async function handleDecideCandidate(checkoutPath, runId, decision, deps = {}) {
 }
 async function handleIntegrateCandidate(checkoutPath, runId, expectedArtifactHash, deps = {}) {
   try {
-    const run = await loadArchivedRun(runId, deps);
-    await requireMatchingCheckout(run, checkoutPath, deps);
-    return await withRepoLock(run.lockKey, async () => {
+    return await withCurrentArchivedRun(checkoutPath, runId, deps, async (run) => {
       if (await run.store.readPipelineActiveMarker(runId) !== null) {
         throw runtimeError(
           "the delegation pipeline for this run is still active",

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -27870,13 +27870,21 @@ async function runAttempt(checkoutPath, spec, deps) {
   const runId = (deps.runId ?? randomUUID4)();
   const store = new ArtifactStore(runId);
   const canonical = await ps.canonicalizePath(checkoutPath);
-  let lock = null;
+  const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
+  if (deps.borrowedCheckoutLease !== void 0 && deps.borrowedCheckoutLease.repositoryIdentity !== repositoryIdentity) {
+    throw new RuntimeError("borrowed checkout lease repository identity mismatch");
+  }
+  let lock = deps.borrowedCheckoutLease?.lock ?? null;
+  let ownedLock = null;
   let worktree = null;
   let tempHome = null;
   let builtEnvironment = null;
   let primaryError;
   try {
-    lock = await ps.acquireCheckoutLock(canonical.canonical);
+    if (lock === null) {
+      ownedLock = await ps.acquireCheckoutLock(canonical.canonical);
+      lock = ownedLock;
+    }
     const preconditions = await checkPreconditions(canonical.canonical, {
       writeAllowlist: spec.writeAllowlist
     });
@@ -28210,7 +28218,7 @@ async function runAttempt(checkoutPath, spec, deps) {
       builtEnvironment,
       worktree,
       tempHome,
-      lock
+      lock: ownedLock
     });
     if (primaryError === void 0 && cleanupError !== null) throw cleanupError;
   }
@@ -29851,10 +29859,43 @@ async function verifyCandidate(args) {
   }
 }
 async function runPipeline(checkoutPath, spec, deps) {
+  const ps = deps.ps ?? getPlatformServices();
+  const canonical = await ps.canonicalizePath(checkoutPath);
+  const lock = await ps.acquireCheckoutLock(canonical.canonical);
+  const borrowedCheckoutLease = {
+    lock,
+    repositoryIdentity: canonical.gitCommonDir ?? canonical.canonical
+  };
+  let primaryError;
+  let hasPrimaryError = false;
+  try {
+    return await runPipelineWithLease(
+      checkoutPath,
+      spec,
+      deps,
+      ps,
+      borrowedCheckoutLease
+    );
+  } catch (error2) {
+    primaryError = error2;
+    hasPrimaryError = true;
+    throw error2;
+  } finally {
+    try {
+      await lock.release();
+    } catch (releaseError) {
+      if (!hasPrimaryError) throw releaseError;
+      throw new AggregateError(
+        [primaryError, releaseError],
+        "pipeline failed and its checkout lease could not be released"
+      );
+    }
+  }
+}
+async function runPipelineWithLease(checkoutPath, spec, deps, ps, borrowedCheckoutLease) {
   const runAttemptFn = deps.runAttempt ?? runAttempt;
   const slices = resolveSlices(spec);
   const initialSpec = slices.length === 0 ? spec : scopeSpecToSlice(spec, slices[0]);
-  const ps = deps.ps ?? getPlatformServices();
   const activeOwner = {
     pid: process.pid,
     processToken: await ps.getProcessStartToken(process.pid).catch(() => null),
@@ -29872,6 +29913,7 @@ async function runPipeline(checkoutPath, spec, deps) {
   const inheritedOnRunStart = deps.onRunStart;
   const attempt = await runAttemptFn(checkoutPath, initialSpec, {
     ...deps,
+    borrowedCheckoutLease,
     async onRunStart(context) {
       runStart = context;
       if (slices.length > 0) {

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -21927,7 +21927,7 @@ var StdioServerTransport = class {
 };
 
 // src/protocol/versions.ts
-var PROTOCOL_VERSION = "1.2.0";
+var PROTOCOL_VERSION = "1.3.0";
 var DELEGATION_SPEC_VERSION = "1";
 var ATTEMPT_RESULT_VERSION = "1";
 var RUNTIME_VERSION = "0.20.0";
@@ -31914,7 +31914,9 @@ var delegatePipelineOutput = external_exports.object({
     rounds: external_exports.array(external_exports.record(external_exports.string(), external_exports.unknown())),
     verification: external_exports.record(external_exports.string(), external_exports.unknown()).nullable(),
     gate: external_exports.record(external_exports.string(), external_exports.unknown()),
-    finalCandidateCommit: external_exports.string()
+    finalCandidateCommit: external_exports.string(),
+    slices: external_exports.array(external_exports.record(external_exports.string(), external_exports.unknown())),
+    haltedSliceIndex: external_exports.number().nullable()
   }).optional(),
   validationErrors: external_exports.array(external_exports.object({ path: external_exports.string(), message: external_exports.string() })).optional(),
   diagnostic: external_exports.string().optional(),

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -29086,6 +29086,7 @@ var IGNORED_STRUCTURAL_FAILURES = /* @__PURE__ */ new Set([
   "artifact-divergence",
   "base-changed"
 ]);
+var SLICE_REF_PREFIX = "refs/claude-architect/slices/";
 function scopeSpecToSlice(spec, slice) {
   const scoped = structuredClone({ ...spec, ...slice });
   delete scoped.slices;
@@ -29099,6 +29100,39 @@ async function checkedGit4(cwd, args, options) {
   const result = await git(cwd, args, options);
   if (result.exitCode !== 0) throw gitFailure5(`git ${args[0] ?? "command"}`, result);
   return result.stdout;
+}
+function temporarySliceRef(runId, index, attempt) {
+  return `${SLICE_REF_PREFIX}${runId}/slice-${index}-attempt-${attempt}`;
+}
+async function createTemporarySliceRef(checkoutPath, temporaryRef) {
+  const result = await git(checkoutPath, [
+    "update-ref",
+    "--no-deref",
+    temporaryRef.ref,
+    temporaryRef.oid,
+    "0".repeat(temporaryRef.oid.length)
+  ]);
+  if (result.exitCode !== 0) throw gitFailure5("create temporary slice ref", result);
+}
+async function cleanupTemporarySliceRefs(checkoutPath, temporaryRefs) {
+  const errors = [];
+  for (const temporaryRef of [...temporaryRefs].reverse()) {
+    try {
+      const result = await git(checkoutPath, [
+        "update-ref",
+        "--no-deref",
+        "-d",
+        temporaryRef.ref,
+        temporaryRef.oid
+      ]);
+      if (result.exitCode !== 0) {
+        errors.push(gitFailure5("delete temporary slice ref", result));
+      }
+    } catch (error2) {
+      errors.push(error2);
+    }
+  }
+  return errors;
 }
 function privateObjectReadOptions(access4) {
   return {
@@ -29270,6 +29304,60 @@ var SliceExecutionError = class extends RuntimeError {
     this.name = "SliceExecutionError";
   }
 };
+function findSliceExecutionError(error2) {
+  if (error2 instanceof SliceExecutionError) return error2;
+  if (!(error2 instanceof AggregateError)) return null;
+  for (const nested of error2.errors) {
+    const found = findSliceExecutionError(nested);
+    if (found !== null) return found;
+  }
+  return null;
+}
+function failedAttemptStatus(failure2) {
+  if (failure2 === "unavailable" || failure2 === "authentication-required") return "unavailable";
+  if (failure2 === "cancelled") return "cancelled";
+  return "failed";
+}
+async function archiveSlicedFailure(args) {
+  const failedAttempt = {
+    ...args.attempt,
+    status: failedAttemptStatus(args.failure),
+    failure: args.failure,
+    summary: args.reason,
+    candidate: args.failure === "verification-failure" ? args.attempt.candidate : null,
+    unresolvedIssues: [...args.attempt.unresolvedIssues, args.reason],
+    evidence: {
+      ...args.attempt.evidence,
+      pipelineFailure: { failure: args.failure, reason: args.reason }
+    }
+  };
+  const manifest = await args.store.readManifest(args.attempt.runId);
+  if (manifest === null) {
+    throw new RuntimeError("run manifest is missing while archiving sliced failure");
+  }
+  await args.store.promoteTerminalArtifacts({ result: failedAttempt, manifest });
+  return failedAttempt;
+}
+async function archiveSliceExecutionError(args) {
+  const sliceError = findSliceExecutionError(args.error);
+  if (sliceError === null) throw args.error;
+  try {
+    return {
+      sliceError,
+      failedAttempt: await archiveSlicedFailure({
+        attempt: args.attempt,
+        failure: sliceError.failure,
+        reason: sliceError.message,
+        store: args.store
+      })
+    };
+  } catch (archiveError) {
+    throw new AggregateError(
+      [args.error, archiveError],
+      "sliced pipeline failed and its attempt result could not be archived"
+    );
+  }
+}
 async function withManagedWorktree(args) {
   const worktree = await args.manager.create(args.commit);
   let primaryError;
@@ -29523,6 +29611,7 @@ async function runIncrement(args) {
   });
 }
 async function validateCandidateProvenance(args) {
+  const phaseLabel = args.phaseLabel ?? "fix phase";
   const privateObjects = privateObjectReadOptions(args.gitObjectAccess);
   const candidateObject = await git(args.worktreePath, [
     "cat-file",
@@ -29532,7 +29621,7 @@ async function validateCandidateProvenance(args) {
   if (candidateObject.exitCode !== 0) {
     return {
       failure: "producer-failure",
-      reason: "fix phase reported a missing candidate commit"
+      reason: `${phaseLabel} reported a missing candidate commit`
     };
   }
   const head = await git(
@@ -29543,7 +29632,7 @@ async function validateCandidateProvenance(args) {
   if (head.exitCode !== 0 || head.stdout.trim() !== args.candidateCommit) {
     return {
       failure: "producer-failure",
-      reason: "fix phase reported a candidate commit that does not match its worktree HEAD"
+      reason: `${phaseLabel} reported a candidate commit that does not match its worktree HEAD`
     };
   }
   const candidateAncestry = await git(args.worktreePath, [
@@ -29555,7 +29644,7 @@ async function validateCandidateProvenance(args) {
   if (candidateAncestry.exitCode !== 0) {
     return {
       failure: "sandbox-violation",
-      reason: "fix phase candidate commit is not descended from the reviewed candidate"
+      reason: `${phaseLabel} candidate commit is not descended from the reviewed candidate`
     };
   }
   const worktreeStatus = await git(args.worktreePath, [
@@ -29566,13 +29655,13 @@ async function validateCandidateProvenance(args) {
   if (worktreeStatus.exitCode !== 0) {
     return {
       failure: "sandbox-violation",
-      reason: "fix phase candidate worktree cleanliness could not be verified"
+      reason: `${phaseLabel} candidate worktree cleanliness could not be verified`
     };
   }
   if (worktreeStatus.stdout.length > 0) {
     return {
       failure: "sandbox-violation",
-      reason: "fix phase candidate worktree contains uncommitted state"
+      reason: `${phaseLabel} candidate worktree contains uncommitted state`
     };
   }
   return null;
@@ -29759,12 +29848,13 @@ async function runPipeline(checkoutPath, spec, deps) {
     startedAt: (/* @__PURE__ */ new Date()).toISOString()
   };
   await store.writePipelineActiveMarker(activeOwner);
+  const temporarySliceRefs2 = [];
+  let finalAttempt = attempt;
   let pipelinePrimaryError;
   try {
     const reviewConfig = resolveReviewConfig(spec);
     const { reviewers, maxRounds } = reviewConfig;
     const maxIncrements = slices.length === 0 ? resolveImplementationConfig(spec).maxIncrements : 1;
-    let finalAttempt = attempt;
     const increments = [];
     let incrementOutcome;
     const rounds = [];
@@ -29772,6 +29862,25 @@ async function runPipeline(checkoutPath, spec, deps) {
     let currentCandidateCommit = attempt.candidate.candidateCommitOid;
     let frozenTestEvidence = testEvidence(attempt);
     let pipelineSlices = [];
+    const archivePipelineFailure = async (args) => {
+      const failedAttempt = slices.length === 0 ? attempt : await archiveSlicedFailure({
+        attempt,
+        failure: args.failure,
+        reason: args.reason,
+        store
+      });
+      finalAttempt = failedAttempt;
+      return failedResult(
+        failedAttempt,
+        rounds,
+        args.finalCandidateCommit,
+        args.reason,
+        args.failure,
+        increments,
+        args.slices ?? pipelineSlices,
+        args.haltedSliceIndex ?? null
+      );
+    };
     if (slices.length > 0) {
       const initialNamespace = "slice-1-attempt-0";
       const initialVerification = await verifyCandidate({
@@ -29787,18 +29896,35 @@ async function runPipeline(checkoutPath, spec, deps) {
       let initialPerSliceReview = null;
       const initialRoleLogRefs = attemptLogRefs(attempt);
       if (reviewConfig.perSlice === true) {
-        const reviewed = await runSliceReview({
-          checkoutPath,
-          spec: initialSpec,
-          deps,
-          runId: attempt.runId,
-          baselineCommit,
-          candidateCommit: currentCandidateCommit,
-          namespace: initialNamespace,
-          reviewers,
-          verification: initialVerification.verification,
-          store
-        });
+        let reviewed;
+        try {
+          reviewed = await runSliceReview({
+            checkoutPath,
+            spec: initialSpec,
+            deps,
+            runId: attempt.runId,
+            baselineCommit,
+            candidateCommit: currentCandidateCommit,
+            namespace: initialNamespace,
+            reviewers,
+            verification: initialVerification.verification,
+            store
+          });
+        } catch (error2) {
+          const archived = await archiveSliceExecutionError({ error: error2, attempt, store });
+          finalAttempt = archived.failedAttempt;
+          if (error2 !== archived.sliceError) throw error2;
+          const failed = failedResult(
+            archived.failedAttempt,
+            rounds,
+            baselineCommit,
+            archived.sliceError.message,
+            archived.sliceError.failure,
+            increments
+          );
+          await store.writePipelineArtifact("pipeline-result", failed);
+          return failed;
+        }
         initialPerSliceReview = reviewed.review;
         initialRoleLogRefs.push(...reviewed.roleLogRefs);
       }
@@ -29863,7 +29989,8 @@ async function runPipeline(checkoutPath, spec, deps) {
                   worktreePath,
                   previousCandidateCommit: base,
                   candidateCommit,
-                  gitObjectAccess: gitObjectAccess2
+                  gitObjectAccess: gitObjectAccess2,
+                  phaseLabel: "slice implementer"
                 });
                 if (provenanceFailure !== null) {
                   throw new SliceExecutionError(
@@ -29885,6 +30012,19 @@ async function runPipeline(checkoutPath, spec, deps) {
                       "sandbox-violation"
                     );
                   }
+                  const temporaryRef = {
+                    ref: temporarySliceRef(attempt.runId, index, sliceAttempt),
+                    oid: candidateCommit
+                  };
+                  try {
+                    await createTemporarySliceRef(checkoutPath, temporaryRef);
+                  } catch {
+                    throw new SliceExecutionError(
+                      "slice candidate temporary ref could not be established",
+                      "sandbox-violation"
+                    );
+                  }
+                  temporarySliceRefs2.push(temporaryRef);
                 }
                 const verified2 = await verifyCandidate({
                   checkoutPath,
@@ -29933,13 +30073,15 @@ async function runPipeline(checkoutPath, spec, deps) {
           }
         });
       } catch (error2) {
-        if (!(error2 instanceof SliceExecutionError)) throw error2;
+        const archived = await archiveSliceExecutionError({ error: error2, attempt, store });
+        finalAttempt = archived.failedAttempt;
+        if (error2 !== archived.sliceError) throw error2;
         const failed = failedResult(
-          attempt,
+          archived.failedAttempt,
           rounds,
           completedSlices.at(-1)?.candidateCommit ?? baselineCommit,
-          error2.message,
-          error2.failure,
+          archived.sliceError.message,
+          archived.sliceError.failure,
           increments,
           completedSlices
         );
@@ -29950,11 +30092,19 @@ async function runPipeline(checkoutPath, spec, deps) {
       currentCandidateCommit = phase.finalCandidateCommit;
       if (phase.haltedSliceIndex !== null) {
         const halted = phase.slices.at(-1);
-        const failed = failedResult(
+        const reason = `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`;
+        const failedAttempt = await archiveSlicedFailure({
           attempt,
+          failure: "verification-failure",
+          reason,
+          store
+        });
+        finalAttempt = failedAttempt;
+        const failed = failedResult(
+          failedAttempt,
           rounds,
           currentCandidateCommit,
-          `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`,
+          reason,
           "verification-failure",
           increments,
           phase.slices,
@@ -30133,15 +30283,12 @@ async function runPipeline(checkoutPath, spec, deps) {
           store
         });
         if (!reviewRun.ok) {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            `review phase did not produce valid structured output (see ${reviewRun.failedRoleLogRef})`,
-            "producer-failure",
-            increments,
-            pipelineSlices
-          );
+          const reason = `review phase did not produce valid structured output (see ${reviewRun.failedRoleLogRef})`;
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason,
+            failure: "producer-failure"
+          });
         }
         const reviews = reviewRun.reviews.map((review) => ({
           reviewer: review.reviewer,
@@ -30164,15 +30311,11 @@ async function runPipeline(checkoutPath, spec, deps) {
         try {
           gitObjectAccess ??= await resolveLinkedWorktreeWritableRoots(candidateWorktree.path);
         } catch {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            "fixer git object isolation could not be established",
-            "sandbox-violation",
-            increments,
-            pipelineSlices
-          );
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason: "fixer git object isolation could not be established",
+            failure: "sandbox-violation"
+          });
         }
         notePhase(`round ${round}: applying fixes`);
         const fixRun = await runFix({
@@ -30187,15 +30330,11 @@ async function runPipeline(checkoutPath, spec, deps) {
           ...runStart === void 0 ? {} : { runStart }
         });
         if (!fixRun.ok) {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            `fix phase did not produce valid structured output (see ${fixRun.failedRoleLogRef})`,
-            fixRun.failure,
-            increments,
-            pipelineSlices
-          );
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason: `fix phase did not produce valid structured output (see ${fixRun.failedRoleLogRef})`,
+            failure: fixRun.failure
+          });
         }
         const { fix } = fixRun;
         await store.writePipelineArtifact(`round-${round}-fix`, fix);
@@ -30206,15 +30345,11 @@ async function runPipeline(checkoutPath, spec, deps) {
           gitObjectAccess
         });
         if (provenanceFailure !== null) {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            provenanceFailure.reason,
-            provenanceFailure.failure,
-            increments,
-            pipelineSlices
-          );
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason: provenanceFailure.reason,
+            failure: provenanceFailure.failure
+          });
         }
         currentCandidateCommit = fix.candidateCommit;
         rounds.push({
@@ -30247,15 +30382,11 @@ async function runPipeline(checkoutPath, spec, deps) {
           ...gitObjectAccess === null ? {} : { privateObjectAccess: gitObjectAccess }
         });
         if (promoted === null) {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            slices.length === 0 ? "fixer objects could not be imported into the shared git object store" : "sliced candidate could not be promoted from the shared git object store",
-            "sandbox-violation",
-            increments,
-            pipelineSlices
-          );
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason: slices.length === 0 ? "fixer objects could not be imported into the shared git object store" : "sliced candidate could not be promoted from the shared git object store",
+            failure: "sandbox-violation"
+          });
         }
         finalAttempt = promoted.attempt;
         currentCandidateCommit = promoted.candidateCommit;
@@ -30315,17 +30446,51 @@ async function runPipeline(checkoutPath, spec, deps) {
     await store.writePipelineArtifact("pipeline-result", result);
     return result;
   } catch (error2) {
-    pipelinePrimaryError = error2;
-    throw error2;
+    let terminalError = error2;
+    if (slices.length > 0 && finalAttempt.status === "verified-candidate") {
+      try {
+        finalAttempt = await archiveSlicedFailure({
+          attempt: finalAttempt,
+          failure: "verification-failure",
+          reason: "sliced pipeline terminated before completing trusted gates",
+          store
+        });
+      } catch (archiveError) {
+        terminalError = new AggregateError(
+          [error2, archiveError],
+          "sliced pipeline failed and its attempt result could not be archived"
+        );
+      }
+    }
+    pipelinePrimaryError = terminalError;
+    throw terminalError;
   } finally {
-    try {
-      await store.clearPipelineActiveMarker();
-    } catch (cleanupError) {
-      if (pipelinePrimaryError === void 0) throw cleanupError;
-      throw new AggregateError(
-        [pipelinePrimaryError, cleanupError],
-        "pipeline failed and its active marker could not be cleared"
-      );
+    const cleanupErrors = await cleanupTemporarySliceRefs(checkoutPath, temporarySliceRefs2);
+    let canClearActiveMarker = true;
+    if (cleanupErrors.length > 0 && slices.length > 0 && finalAttempt.status === "verified-candidate") {
+      try {
+        finalAttempt = await archiveSlicedFailure({
+          attempt: finalAttempt,
+          failure: "verification-failure",
+          reason: "temporary slice ref cleanup did not complete",
+          store
+        });
+      } catch (archiveError) {
+        cleanupErrors.push(archiveError);
+        canClearActiveMarker = false;
+      }
+    }
+    if (canClearActiveMarker) {
+      try {
+        await store.clearPipelineActiveMarker();
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
+    if (cleanupErrors.length > 0) {
+      const errors = pipelinePrimaryError === void 0 ? cleanupErrors : [pipelinePrimaryError, ...cleanupErrors];
+      if (errors.length === 1) throw errors[0];
+      throw new AggregateError(errors, "pipeline failed or its terminal cleanup was incomplete");
     }
   }
 }
@@ -30773,6 +30938,7 @@ var LOCK_NAME = /^([0-9a-f]{64})\.lock$/;
 var OID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 var CANDIDATE_REF_PREFIX2 = "refs/claude-architect/candidates/";
 var BACKUP_REF_PREFIX = "refs/claude-architect/prune-backups/";
+var SLICE_REF_PREFIX2 = "refs/claude-architect/slices/";
 function errorCode4(error2) {
   return error2.code;
 }
@@ -30929,21 +31095,21 @@ async function validateRepositoryRoot(repoRoot) {
   }
   return canonical;
 }
-async function readDirectRef(repoRoot, ref) {
-  const symbolic = await git(repoRoot, ["symbolic-ref", "--quiet", ref]);
+async function readDirectRef(repoRoot, ref, runGit = git) {
+  const symbolic = await runGit(repoRoot, ["symbolic-ref", "--quiet", ref]);
   if (symbolic.exitCode === 0) {
     throw new RuntimeError("recovery refuses to mutate a symbolic Git ref");
   }
   if (symbolic.exitCode !== 1) throw runGitError("inspect symbolic Git ref", symbolic);
-  const direct = await git(repoRoot, ["rev-parse", "--verify", "--quiet", ref]);
+  const direct = await runGit(repoRoot, ["rev-parse", "--verify", "--quiet", ref]);
   if (direct.exitCode === 1) return null;
   if (direct.exitCode !== 0 || !OID.test(direct.stdout.trim())) {
     throw runGitError("inspect Git ref", direct);
   }
   return direct.stdout.trim();
 }
-async function deleteExactRef(repoRoot, ref, oid) {
-  const result = await git(repoRoot, ["update-ref", "--no-deref", "-d", ref, oid]);
+async function deleteExactRef(repoRoot, ref, oid, runGit = git) {
+  const result = await runGit(repoRoot, ["update-ref", "--no-deref", "-d", ref, oid]);
   if (result.exitCode !== 0) throw runGitError("delete recovery Git ref", result);
 }
 async function createExactRef(repoRoot, ref, oid) {
@@ -30960,6 +31126,106 @@ async function removeStaleCandidateAnchor(repoRoot, runId) {
   const ref = `${CANDIDATE_REF_PREFIX2}${runId}`;
   const oid = await readDirectRef(repoRoot, ref);
   if (oid !== null) await deleteExactRef(repoRoot, ref, oid);
+}
+async function archiveInterruptedPipeline(store, result) {
+  if (result.status !== "verified-candidate") return;
+  const manifest = await store.readManifest(result.runId);
+  if (manifest === null) {
+    throw new RuntimeError("run manifest is missing while recovering interrupted pipeline");
+  }
+  const failed = {
+    ...result,
+    status: "failed",
+    failure: "verification-failure",
+    summary: "Delegation pipeline was interrupted before trusted gates completed.",
+    unresolvedIssues: [
+      ...result.unresolvedIssues,
+      "pipeline-interrupted-before-terminal-cleanup"
+    ],
+    evidence: {
+      ...result.evidence,
+      pipelineRecovery: "interrupted-before-terminal-cleanup"
+    }
+  };
+  await store.promoteTerminalArtifacts({ result: failed, manifest });
+}
+function escapeRegex5(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function isManagedWorktreeId(runId, managedId) {
+  if ((/* @__PURE__ */ new Set([
+    runId,
+    `baseline-${runId}`,
+    `verify-${runId}`,
+    `${runId}-pipeline`,
+    `${runId}-verify`,
+    `verify-${runId}-pipeline`,
+    `${runId}-composed-review`,
+    `${runId}-final-verify`,
+    `verify-${runId}-final-pipeline`
+  ])).has(managedId)) return true;
+  const escapedRunId = escapeRegex5(runId);
+  const index = "[1-9][0-9]*";
+  const attempt = "(?:0|[1-9][0-9]*)";
+  return new RegExp(
+    `^${escapedRunId}-slice-${index}-attempt-${attempt}(?:-review|-verify)?$`
+  ).test(managedId) || new RegExp(
+    `^verify-${escapedRunId}-slice-${index}-attempt-${attempt}-pipeline$`
+  ).test(managedId);
+}
+async function managedWorktreeIds(root, runId) {
+  const worktreesRoot = path14.join(root, "worktrees");
+  if (await plainDirectoryIdentity(worktreesRoot) === null) return [];
+  const entries = await readdir2(worktreesRoot, { withFileTypes: true });
+  return entries.map((entry) => entry.name).filter((managedId) => isManagedWorktreeId(runId, managedId)).sort((left, right) => left.localeCompare(right));
+}
+async function cleanupManagedWorktrees(commonDir, root, runId, ps) {
+  for (const managedId of await managedWorktreeIds(root, runId)) {
+    const worktreePath = path14.join(root, "worktrees", managedId);
+    if (await plainDirectoryIdentity(worktreePath) !== null) {
+      await new WorktreeManager(commonDir, managedId, ps).remove(worktreePath);
+    }
+  }
+}
+async function temporarySliceRefs(repoRoot, runId, runGit) {
+  const prefix = `${SLICE_REF_PREFIX2}${runId}/`;
+  const listed = await runGit(repoRoot, [
+    "for-each-ref",
+    "--format=%(refname)%09%(objectname)",
+    prefix
+  ]);
+  if (listed.exitCode !== 0) throw runGitError("enumerate temporary slice refs", listed);
+  const expectedName = new RegExp(
+    `^${escapeRegex5(prefix)}slice-[1-9][0-9]*-attempt-(?:0|[1-9][0-9]*)$`
+  );
+  const refs = [];
+  for (const line of listed.stdout.split("\n").filter(Boolean)) {
+    const fields = line.split("	");
+    if (fields.length !== 2 || fields[0] === void 0 || !expectedName.test(fields[0])) {
+      throw new RuntimeError("temporary slice ref name is malformed during recovery");
+    }
+    if (fields[1] === void 0 || !OID.test(fields[1])) {
+      throw new RuntimeError("temporary slice ref OID is malformed during recovery");
+    }
+    const object3 = await runGit(repoRoot, ["cat-file", "-t", fields[1]]);
+    if (object3.exitCode !== 0 || object3.stdout.trim() !== "commit") {
+      throw new RuntimeError("temporary slice ref does not identify a commit during recovery");
+    }
+    refs.push({ ref: fields[0], oid: fields[1] });
+  }
+  for (const temporaryRef of refs) {
+    const current = await readDirectRef(repoRoot, temporaryRef.ref, runGit);
+    if (current !== temporaryRef.oid) {
+      throw new RuntimeError("temporary slice ref moved during recovery");
+    }
+  }
+  return refs;
+}
+async function cleanupTemporarySliceRefs2(repoRoot, runId, runGit) {
+  const refs = await temporarySliceRefs(repoRoot, runId, runGit);
+  for (const temporaryRef of refs) {
+    await deleteExactRef(repoRoot, temporaryRef.ref, temporaryRef.oid, runGit);
+  }
 }
 function parseCleanupRecord(line) {
   let value;
@@ -31107,7 +31373,7 @@ async function replayInterruptedPrunes(runsRoot) {
     });
   }
 }
-async function recoverRun(record2, root, ps, isProcessAlive, requestCooperativeTermination, delayMs, graceMs) {
+async function recoverRun(record2, root, ps, isProcessAlive, requestCooperativeTermination, delayMs, graceMs, runGit) {
   let escalation;
   if (record2.pid !== null && isProcessAlive(record2.pid)) {
     const liveToken = record2.processToken === null ? null : await ps.getProcessStartToken(record2.pid);
@@ -31128,19 +31394,8 @@ async function recoverRun(record2, root, ps, isProcessAlive, requestCooperativeT
     "recovery",
     "startup recovery reclaimed unfinished run\n"
   );
-  for (const managedId of [
-    record2.runId,
-    `baseline-${record2.runId}`,
-    `verify-${record2.runId}`,
-    `${record2.runId}-pipeline`,
-    `${record2.runId}-verify`
-  ]) {
-    const worktreePath = path14.join(root, "worktrees", managedId);
-    const worktreeIdentity = await plainDirectoryIdentity(worktreePath);
-    if (worktreeIdentity !== null) {
-      await new WorktreeManager(commonDir, managedId, ps).remove(worktreePath);
-    }
-  }
+  await cleanupManagedWorktrees(commonDir, root, record2.runId, ps);
+  await cleanupTemporarySliceRefs2(commonDir, record2.runId, runGit);
   await removeStaleCandidateAnchor(commonDir, record2.runId);
   await store.writeResult({
     resultVersion: "1",
@@ -31250,6 +31505,7 @@ async function recoverStaleRuns(dependencies = {}) {
   const requestCooperativeTermination = dependencies.requestCooperativeTermination ?? defaultRequestCooperativeTermination;
   const delayMs = dependencies.delayMs ?? defaultDelayMs;
   const graceMs = dependencies.graceMs ?? 3e3;
+  const runGit = dependencies.git ?? git;
   const locksRoot = path14.join(root, "locks");
   const stale = [];
   if (runsIdentity !== null) {
@@ -31271,15 +31527,9 @@ async function recoverStaleRuns(dependencies = {}) {
           (pid) => ps.getProcessStartToken(pid)
         )) {
           const commonDir = await validateGitCommonDir(record2.canonicalCommonDir);
-          for (const managedId of [
-            `${entry.name}-pipeline`,
-            `${entry.name}-verify`
-          ]) {
-            const worktreePath = path14.join(root, "worktrees", managedId);
-            if (await plainDirectoryIdentity(worktreePath) !== null) {
-              await new WorktreeManager(commonDir, managedId, ps).remove(worktreePath);
-            }
-          }
+          await archiveInterruptedPipeline(store, result);
+          await cleanupManagedWorktrees(commonDir, root, entry.name, ps);
+          await cleanupTemporarySliceRefs2(commonDir, entry.name, runGit);
           await store.clearPipelineActiveMarker();
         }
         continue;
@@ -31302,7 +31552,8 @@ async function recoverStaleRuns(dependencies = {}) {
       isProcessAlive,
       requestCooperativeTermination,
       delayMs,
-      graceMs
+      graceMs,
+      runGit
     );
     recovered.push(record2.runId);
   }

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -29067,12 +29067,14 @@ async function runStructuredRole(args) {
     roleLogRefs
   };
 }
-function failedResult(attempt, rounds, finalCandidateCommit, reason, failure2 = "producer-failure", increments = []) {
+function failedResult(attempt, rounds, finalCandidateCommit, reason, failure2 = "producer-failure", increments = [], slices = [], haltedSliceIndex = null) {
   return {
     runId: attempt.runId,
     status: "failed",
     attempt,
     increments,
+    slices,
+    haltedSliceIndex,
     rounds,
     verification: null,
     gate: {
@@ -29158,6 +29160,60 @@ async function candidateArtifact(args) {
     manifestHash: canonical.manifestHash
   };
 }
+async function promoteFinalCandidate(args) {
+  let canonicalCommit;
+  try {
+    const objectReadOptions = args.privateObjectAccess === void 0 ? void 0 : privateObjectReadOptions(args.privateObjectAccess);
+    const finalTree = (await checkedGit4(
+      args.checkoutPath,
+      ["rev-parse", `${args.candidateCommit}^{tree}`],
+      objectReadOptions
+    )).trim();
+    canonicalCommit = (await checkedGit4(args.checkoutPath, [
+      "commit-tree",
+      finalTree,
+      "-p",
+      args.baselineCommit,
+      "-m",
+      `candidate ${args.attempt.runId}`
+    ], objectReadOptions)).trim();
+    if (args.privateObjectAccess !== void 0) {
+      await importPromotedObjects({
+        checkoutPath: args.checkoutPath,
+        baselineCommit: args.baselineCommit,
+        promotedCommit: canonicalCommit,
+        access: args.privateObjectAccess
+      });
+    }
+  } catch {
+    return null;
+  }
+  await checkedGit4(args.checkoutPath, [
+    "update-ref",
+    args.initialCandidate.anchorRef,
+    canonicalCommit,
+    args.initialCandidate.candidateCommitOid
+  ]);
+  const diffText = await checkedGit4(
+    args.checkoutPath,
+    ["diff", `${args.baselineCommit}..${canonicalCommit}`]
+  );
+  const candidate = await candidateArtifact({
+    worktreePath: args.checkoutPath,
+    baselineCommit: args.baselineCommit,
+    candidateCommit: canonicalCommit,
+    anchorRef: args.initialCandidate.anchorRef,
+    diffText
+  });
+  const manifest = await args.store.readManifest(args.attempt.runId);
+  if (manifest === null) throw new RuntimeError("run manifest is missing during promotion");
+  const finalAttempt = { ...args.attempt, candidate };
+  await args.store.promoteTerminalArtifacts({
+    result: finalAttempt,
+    manifest: { ...manifest, candidateManifestHash: candidate.manifestHash }
+  });
+  return { attempt: finalAttempt, candidateCommit: canonicalCommit };
+}
 function detectWeakenedTests(diff) {
   let testsDeleted = 0;
   let testsSkipped = 0;
@@ -29175,12 +29231,13 @@ function detectWeakenedTests(diff) {
   return { testsDeleted, testsSkipped };
 }
 async function runReviews(args) {
+  const logNameNamespace = args.logNameNamespace === void 0 ? "" : `${args.logNameNamespace}-`;
   const outcomes = await Promise.all(args.reviewers.map(async (reviewer) => {
     const role = `reviewer-${reviewer}`;
     const outcome = await runStructuredRole({
       role,
       schema: schemas.reviewReport,
-      logName: `role-${role}-round${args.round}`,
+      logName: `role-${role}-${logNameNamespace}round${args.round}`,
       spec: args.spec,
       pkg: args.pkg,
       worktreePath: args.worktreePath,
@@ -29222,10 +29279,11 @@ async function runFix(args) {
   return outcome.ok ? { ok: true, fix: outcome.report, roleLogRefs: outcome.roleLogRefs } : outcome;
 }
 async function runIncrement(args) {
+  const logNameNamespace = args.logNameNamespace === void 0 ? "" : `${args.logNameNamespace}-`;
   return runStructuredRole({
     role: "implementer",
     schema: schemas.incrementReport,
-    logName: `role-implementer-increment${args.increment}`,
+    logName: `role-implementer-${logNameNamespace}increment${args.increment}`,
     spec: args.spec,
     pkg: args.pkg,
     worktreePath: args.worktreePath,
@@ -29338,9 +29396,10 @@ async function validateFixProvenance(args) {
 }
 async function verifyCandidate(args) {
   const ps = args.deps.ps ?? getPlatformServices();
+  const namespace = args.namespace === void 0 ? "" : `${args.namespace}-`;
   const manager = new WorktreeManager(
     args.checkoutPath,
-    `${args.attempt.runId}-verify`,
+    `${args.attempt.runId}-${namespace}verify`,
     ps
   );
   const fresh = await manager.create(args.candidateCommit);
@@ -29385,8 +29444,8 @@ async function verifyCandidate(args) {
       spec: args.spec,
       ps,
       artifactStore: args.store,
-      verificationId: () => `${args.attempt.runId}-pipeline`,
-      logNamePrefix: "pipeline-verification"
+      verificationId: () => `${args.attempt.runId}-${namespace}pipeline`,
+      logNamePrefix: `${namespace}pipeline-verification`
     });
     const changedPaths = nameOnly.split("\n").map((line) => line.trim()).filter(Boolean);
     const scopeViolations = changedPaths.filter((pathname) => !args.spec.writeAllowlist.some((pattern) => globMatches3(pattern, pathname)) || args.spec.forbiddenScope.some((pattern) => globMatches3(pattern, pathname)));
@@ -29743,29 +29802,16 @@ async function runPipeline(checkoutPath, spec, deps) {
             increments
           );
         }
-        let canonicalCommit;
-        try {
-          const privateObjects = privateObjectReadOptions(gitObjectAccess);
-          const finalTree = (await checkedGit4(
-            checkoutPath,
-            ["rev-parse", `${currentCandidateCommit}^{tree}`],
-            privateObjects
-          )).trim();
-          canonicalCommit = (await checkedGit4(checkoutPath, [
-            "commit-tree",
-            finalTree,
-            "-p",
-            baselineCommit,
-            "-m",
-            `candidate ${attempt.runId}`
-          ], privateObjects)).trim();
-          await importPromotedObjects({
-            checkoutPath,
-            baselineCommit,
-            promotedCommit: canonicalCommit,
-            access: gitObjectAccess
-          });
-        } catch {
+        const promoted = await promoteFinalCandidate({
+          checkoutPath,
+          attempt,
+          initialCandidate: attempt.candidate,
+          baselineCommit,
+          candidateCommit: currentCandidateCommit,
+          store,
+          privateObjectAccess: gitObjectAccess
+        });
+        if (promoted === null) {
           return failedResult(
             attempt,
             rounds,
@@ -29775,31 +29821,8 @@ async function runPipeline(checkoutPath, spec, deps) {
             increments
           );
         }
-        await checkedGit4(checkoutPath, [
-          "update-ref",
-          attempt.candidate.anchorRef,
-          canonicalCommit,
-          attempt.candidate.candidateCommitOid
-        ]);
-        currentCandidateCommit = canonicalCommit;
-        const diffText = await checkedGit4(
-          checkoutPath,
-          ["diff", `${baselineCommit}..${canonicalCommit}`]
-        );
-        const candidate = await candidateArtifact({
-          worktreePath: checkoutPath,
-          baselineCommit,
-          candidateCommit: canonicalCommit,
-          anchorRef: attempt.candidate.anchorRef,
-          diffText
-        });
-        const manifest = await store.readManifest(attempt.runId);
-        if (manifest === null) throw new RuntimeError("run manifest is missing during promotion");
-        finalAttempt = { ...attempt, candidate };
-        await store.promoteTerminalArtifacts({
-          result: finalAttempt,
-          manifest: { ...manifest, candidateManifestHash: candidate.manifestHash }
-        });
+        finalAttempt = promoted.attempt;
+        currentCandidateCommit = promoted.candidateCommit;
       }
     } catch (error2) {
       primaryError = error2;
@@ -29844,6 +29867,8 @@ async function runPipeline(checkoutPath, spec, deps) {
       status: gate.decisionReady ? "decision-ready" : "human-decision-required",
       attempt: finalAttempt,
       increments,
+      slices: [],
+      haltedSliceIndex: null,
       rounds,
       verification: verified.verification,
       gate,

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -29089,6 +29089,7 @@ var IGNORED_STRUCTURAL_FAILURES = /* @__PURE__ */ new Set([
   "artifact-divergence",
   "base-changed"
 ]);
+var CANDIDATE_REF_PREFIX2 = "refs/claude-architect/candidates/";
 var SLICE_REF_PREFIX = "refs/claude-architect/slices/";
 function scopeSpecToSlice(spec, slice) {
   const scoped = structuredClone({ ...spec, ...slice });
@@ -29307,6 +29308,13 @@ var SliceExecutionError = class extends RuntimeError {
     this.name = "SliceExecutionError";
   }
 };
+var SlicedFailureArchiveError = class extends RuntimeError {
+  constructor(cause) {
+    super(cause instanceof Error ? cause.message : "sliced failure archival failed");
+    this.cause = cause;
+    this.name = "SlicedFailureArchiveError";
+  }
+};
 function findSliceExecutionError(error2) {
   if (error2 instanceof SliceExecutionError) return error2;
   if (!(error2 instanceof AggregateError)) return null;
@@ -29316,30 +29324,56 @@ function findSliceExecutionError(error2) {
   }
   return null;
 }
+function containsSlicedFailureArchiveError(error2) {
+  if (error2 instanceof SlicedFailureArchiveError) return true;
+  if (!(error2 instanceof AggregateError)) return false;
+  return error2.errors.some(containsSlicedFailureArchiveError);
+}
 function failedAttemptStatus(failure2) {
   if (failure2 === "unavailable" || failure2 === "authentication-required") return "unavailable";
   if (failure2 === "cancelled") return "cancelled";
   return "failed";
 }
 async function archiveSlicedFailure(args) {
-  const failedAttempt = {
-    ...args.attempt,
-    status: failedAttemptStatus(args.failure),
-    failure: args.failure,
-    summary: args.reason,
-    candidate: args.failure === "verification-failure" ? args.attempt.candidate : null,
-    unresolvedIssues: [...args.attempt.unresolvedIssues, args.reason],
-    evidence: {
-      ...args.attempt.evidence,
-      pipelineFailure: { failure: args.failure, reason: args.reason }
+  try {
+    const manifest = await args.store.readManifest(args.attempt.runId);
+    if (manifest === null) {
+      throw new RuntimeError("run manifest is missing while archiving sliced failure");
     }
-  };
-  const manifest = await args.store.readManifest(args.attempt.runId);
-  if (manifest === null) {
-    throw new RuntimeError("run manifest is missing while archiving sliced failure");
+    const retainCandidate = args.failure === "verification-failure";
+    if (!retainCandidate && args.attempt.candidate !== null) {
+      const candidate = args.attempt.candidate;
+      const expectedRef = `${CANDIDATE_REF_PREFIX2}${args.attempt.runId}`;
+      if (candidate.anchorRef !== expectedRef) {
+        throw new RuntimeError("sliced candidate anchor does not match run id");
+      }
+      const deleted = await git(args.checkoutPath, [
+        "update-ref",
+        "--no-deref",
+        "-d",
+        candidate.anchorRef,
+        candidate.candidateCommitOid
+      ]);
+      if (deleted.exitCode !== 0) throw gitFailure5("delete sliced candidate anchor", deleted);
+    }
+    const failedAttempt = {
+      ...args.attempt,
+      status: failedAttemptStatus(args.failure),
+      failure: args.failure,
+      summary: args.reason,
+      candidate: retainCandidate ? args.attempt.candidate : null,
+      unresolvedIssues: [...args.attempt.unresolvedIssues, args.reason],
+      evidence: {
+        ...args.attempt.evidence,
+        pipelineFailure: { failure: args.failure, reason: args.reason }
+      }
+    };
+    await args.store.promoteTerminalArtifacts({ result: failedAttempt, manifest });
+    return failedAttempt;
+  } catch (error2) {
+    if (error2 instanceof SlicedFailureArchiveError) throw error2;
+    throw new SlicedFailureArchiveError(error2);
   }
-  await args.store.promoteTerminalArtifacts({ result: failedAttempt, manifest });
-  return failedAttempt;
 }
 async function archiveSliceExecutionError(args) {
   const sliceError = findSliceExecutionError(args.error);
@@ -29348,6 +29382,7 @@ async function archiveSliceExecutionError(args) {
     return {
       sliceError,
       failedAttempt: await archiveSlicedFailure({
+        checkoutPath: args.checkoutPath,
         attempt: args.attempt,
         failure: sliceError.failure,
         reason: sliceError.message,
@@ -29875,6 +29910,7 @@ async function runPipeline(checkoutPath, spec, deps) {
     let pipelineSlices = [];
     const archivePipelineFailure = async (args) => {
       const failedAttempt = slices.length === 0 ? attempt : await archiveSlicedFailure({
+        checkoutPath,
         attempt,
         failure: args.failure,
         reason: args.reason,
@@ -29923,7 +29959,12 @@ async function runPipeline(checkoutPath, spec, deps) {
             store
           });
         } catch (error2) {
-          const archived = await archiveSliceExecutionError({ error: error2, attempt, store });
+          const archived = await archiveSliceExecutionError({
+            checkoutPath,
+            error: error2,
+            attempt,
+            store
+          });
           authoritySafeToRelease = true;
           finalAttempt = archived.failedAttempt;
           if (error2 !== archived.sliceError) throw error2;
@@ -30086,7 +30127,12 @@ async function runPipeline(checkoutPath, spec, deps) {
           }
         });
       } catch (error2) {
-        const archived = await archiveSliceExecutionError({ error: error2, attempt, store });
+        const archived = await archiveSliceExecutionError({
+          checkoutPath,
+          error: error2,
+          attempt,
+          store
+        });
         authoritySafeToRelease = true;
         finalAttempt = archived.failedAttempt;
         if (error2 !== archived.sliceError) throw error2;
@@ -30108,6 +30154,7 @@ async function runPipeline(checkoutPath, spec, deps) {
         const halted = phase.slices.at(-1);
         const reason = `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`;
         const failedAttempt = await archiveSlicedFailure({
+          checkoutPath,
           attempt,
           failure: "verification-failure",
           reason,
@@ -30463,9 +30510,10 @@ async function runPipeline(checkoutPath, spec, deps) {
     return result;
   } catch (error2) {
     let terminalError = error2;
-    if (slices.length > 0 && finalAttempt.status === "verified-candidate") {
+    if (slices.length > 0 && finalAttempt.status === "verified-candidate" && !containsSlicedFailureArchiveError(error2)) {
       try {
         finalAttempt = await archiveSlicedFailure({
+          checkoutPath,
           attempt: finalAttempt,
           failure: "verification-failure",
           reason: "sliced pipeline terminated before completing trusted gates",
@@ -30483,9 +30531,10 @@ async function runPipeline(checkoutPath, spec, deps) {
     throw terminalError;
   } finally {
     const cleanupErrors = await cleanupTemporarySliceRefs(checkoutPath, temporarySliceRefs2);
-    if (cleanupErrors.length > 0 && slices.length > 0 && finalAttempt.status === "verified-candidate") {
+    if (cleanupErrors.length > 0 && slices.length > 0 && finalAttempt.status === "verified-candidate" && !containsSlicedFailureArchiveError(pipelinePrimaryError)) {
       try {
         finalAttempt = await archiveSlicedFailure({
+          checkoutPath,
           attempt: finalAttempt,
           failure: "verification-failure",
           reason: "temporary slice ref cleanup did not complete",
@@ -30952,7 +31001,7 @@ var MAX_STATE_FILE_BYTES = 8e6;
 var SAFE_RUN_ID = /^[a-z0-9][a-z0-9._-]*$/;
 var LOCK_NAME = /^([0-9a-f]{64})\.lock$/;
 var OID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
-var CANDIDATE_REF_PREFIX2 = "refs/claude-architect/candidates/";
+var CANDIDATE_REF_PREFIX3 = "refs/claude-architect/candidates/";
 var BACKUP_REF_PREFIX = "refs/claude-architect/prune-backups/";
 var SLICE_REF_PREFIX2 = "refs/claude-architect/slices/";
 function errorCode4(error2) {
@@ -31139,7 +31188,7 @@ async function createExactRef(repoRoot, ref, oid) {
   if (result.exitCode !== 0) throw runGitError("create recovery Git ref", result);
 }
 async function removeStaleCandidateAnchor(repoRoot, runId) {
-  const ref = `${CANDIDATE_REF_PREFIX2}${runId}`;
+  const ref = `${CANDIDATE_REF_PREFIX3}${runId}`;
   const oid = await readDirectRef(repoRoot, ref);
   if (oid !== null) await deleteExactRef(repoRoot, ref, oid);
 }
@@ -31270,7 +31319,7 @@ function parseCleanupRecord(line) {
   }
   const hasRepository = typeof record2.repoRoot === "string" && typeof record2.anchorRef === "string" && typeof record2.candidateCommitOid === "string";
   const noRepository = record2.repoRoot === null && record2.anchorRef === null && record2.backupRef === null && record2.candidateCommitOid === null;
-  if (!noRepository && (!hasRepository || record2.anchorRef !== `${CANDIDATE_REF_PREFIX2}${record2.runId}` || !OID.test(record2.candidateCommitOid) || record2.backupRef !== null && record2.backupRef !== `${BACKUP_REF_PREFIX}${record2.runId}`)) {
+  if (!noRepository && (!hasRepository || record2.anchorRef !== `${CANDIDATE_REF_PREFIX3}${record2.runId}` || !OID.test(record2.candidateCommitOid) || record2.backupRef !== null && record2.backupRef !== `${BACKUP_REF_PREFIX}${record2.runId}`)) {
     throw new RuntimeError("cleanup journal Git metadata is malformed");
   }
   return record2;

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -93,7 +93,7 @@ Surface every delegation in the Claude Code subagent look & feel. This is presen
 
 **Dispatch card** — emit when you call `delegate`/`delegatePipeline`, so the run reads like an `Agent` launch:
 
-```
+```text
 ▸ Agent · codex-implementer          edit · worktree-isolated
   Task    <3–5 word description>
   Model   GPT-5.6 Sol · reasoning low
@@ -102,7 +102,7 @@ Surface every delegation in the Claude Code subagent look & feel. This is presen
 
 **Live status** — one FleetView-style line while the call runs and after the host collapses it to background. Derive it only from the run's durable artifacts using the rules in *Monitoring a backgrounded delegation*; never invent progress.
 
-```
+```text
 ● running · codex-implementer · verification · 4m12s
 ```
 
@@ -110,7 +110,7 @@ Status glyphs: `●` running · `◑` decision-ready / human-decision-required �
 
 **Completion notification** — when the call returns, render one compact box populated from the `reviewCandidate` evidence and verification report (mirrors a background subagent's completion notice):
 
-```
+```text
 ┌ ✓ codex-implementer · verified-candidate ───────────────
 │ 6 files · verification 5/5 pass
 │ findings 1 major (fixed in-pipeline) · 0 open

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -149,17 +149,23 @@ Slice rules and guarantees:
   own `verification`. Each slice's `writeAllowlist` must be a subset of the
   spec's, and its verification `cwd` must stay inside the candidate root.
 - A deterministic wayfinder routes each completed slice **advance / repair /
-  halt** from its verification result alone — no model judgment. A slice that
-  passes advances; a slice that fails is repaired within its round budget; a
-  slice that cannot be made to pass halts the run.
+  halt** from objective gate results — the slice's own `verification`, plus its
+  independent per-slice review findings when `review.perSlice` is enabled —
+  never from model judgment or a Producer's self-report. A slice that passes
+  advances; a slice that fails is repaired within its round budget; a slice that
+  cannot be made to pass halts the run.
 - Review and the advisor judge the **composed candidate** at the end, over the
   whole slice branch. Per-slice review is off by default; opt in with
   `review.perSlice: true` to review each slice as it lands.
-- A mid-run halt yields a **partial** candidate with
-  `status: "human-decision-required"`, the halted slice index in
-  `haltedSliceIndex`, and each slice's route in `slices`. Present the completed
-  slices, the halt reason, and the partial candidate to the human; never accept
-  or continue past a halt on their behalf.
+- A mid-run halt **after at least one slice has advanced** yields a **partial**
+  candidate with `status: "human-decision-required"`, the halted slice index in
+  `haltedSliceIndex`, and each slice's route in `slices`; the promoted partial
+  branch (the advanced slices) is a real candidate the human may accept, reject,
+  or revise, and the halted slice's attempts stay in `slices` as evidence. A
+  halt on the very first slice, with nothing advanced, is reported `failed` with
+  the slice evidence retained — there is no partial branch to accept. Present
+  the completed slices, the halt reason, and the partial candidate to the human;
+  never accept or continue past a halt on their behalf.
 
 ## Monitoring a backgrounded delegation
 

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -13,7 +13,16 @@ The current session is the architect. It owns requirements, the Delegation Spec,
 
 Always present this skill as `/claude-architect:delegate`. Never show a shorter command.
 
-## Producer selection
+## Agent selection
+
+The delegated CLIs are the architect's **implementation agents** — the same subagent idiom Claude Code uses, except each agent launches an *untrusted Producer* through the trusted MCP runtime inside an isolated Git worktree. Present them as a selectable agent roster: the human picks one `subagent_type`, exactly one agent runs per attempt, and no agent may review or accept its own work.
+
+| Agent (`subagent_type`) | Producer / model | Reasoning control |
+| --- | --- | --- |
+| `codex-implementer` | GPT-5.6 Sol (OpenAI Codex CLI) | `low` by default |
+| `opencode-implementer` | OpenCode provider/model | optional `--variant` |
+| `pi-implementer` | Pi configured model | optional `--thinking` |
+| `pythinker-implementer` | Pythinker provider/model | optional `--thinking-effort` |
 
 If the user invokes `/claude-architect:delegate` without naming a CLI, implementer, or agent, use the host's structured question tool when available, ask this question, and wait for the answer. Include the producer and reasoning control in each option so the user knows what the lane will run:
 
@@ -77,6 +86,39 @@ The `delegate` and `delegatePipeline` MCP calls are synchronous. Keep each call 
 7. Only after an accepted decision, call `integrateCandidate` with `checkoutPath`, the run id, and the exact candidate `manifestHash` as `expectedArtifactHash`. Report `applied`, `conflicted`, or `aborted` truthfully. Integration stages the reviewed tree but does not commit it.
 
 Never accept a Producer self-report as evidence, bypass `reviewCandidate`, call integration before an accepted decision, or substitute a different artifact hash.
+
+## Presenting delegations as subagents
+
+Surface every delegation in the Claude Code subagent look & feel. This is presentation only: it renders the runtime's durable evidence and never replaces spec construction, `reviewCandidate`, the human decision, or `integrateCandidate`. A rendered card is not evidence; a Producer self-report is not evidence; acceptance stays human-only.
+
+**Dispatch card** — emit when you call `delegate`/`delegatePipeline`, so the run reads like an `Agent` launch:
+
+```
+▸ Agent · codex-implementer          edit · worktree-isolated
+  Task    <3–5 word description>
+  Model   GPT-5.6 Sol · reasoning low
+  Mode    foreground        Pipeline  delegatePipeline
+```
+
+**Live status** — one FleetView-style line while the call runs and after the host collapses it to background. Derive it only from the run's durable artifacts using the rules in *Monitoring a backgrounded delegation*; never invent progress.
+
+```
+● running · codex-implementer · verification · 4m12s
+```
+
+Status glyphs: `●` running · `◑` decision-ready / human-decision-required · `✓` verified-candidate · `✗` failed, unavailable, or cancelled.
+
+**Completion notification** — when the call returns, render one compact box populated from the `reviewCandidate` evidence and verification report (mirrors a background subagent's completion notice):
+
+```
+┌ ✓ codex-implementer · verified-candidate ───────────────
+│ 6 files · verification 5/5 pass
+│ findings 1 major (fixed in-pipeline) · 0 open
+│ manifestHash 1f2e3d… → awaiting your decision
+└──────────────────────────────────────────────────────────
+```
+
+The box summarizes; it does not decide. Still read the exact unredacted patch, changed-path manifest, and verification evidence before recommending a decision, and present `failed` or `human-decision-required` outcomes verbatim.
 
 ## Choosing delegate vs delegatePipeline
 
@@ -191,8 +233,8 @@ Correlate the run without guessing:
    implement attempt (baseline or producer) is still running. `result.json`
    appearing means the run finished.
 
-After backgrounding the host returns control once; emit a single status line
-then. Continuous status requires scheduled wakeups (about 75s apart, each a full
+After backgrounding the host returns control once; emit a single Live status
+line (the FleetView-style format above) then. Continuous status requires scheduled wakeups (about 75s apart, each a full
 turn) — only do this when the human explicitly asks for live status, tell them it
 costs a turn per update, and never poll tighter than the round cadence.
 

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -6,7 +6,7 @@ description: Let Claude Architect route a versioned implementation spec through 
 # Delegate
 
 ```claude-architect-protocol
-PROTOCOL_VERSION: 1.2.0
+PROTOCOL_VERSION: 1.3.0
 ```
 
 The current session is the architect. It owns requirements, the Delegation Spec, Producer selection, review, and acceptance. Producers are untrusted: their output is only a candidate until the runtime freezes it, independently verifies it, and the architect reviews the exact anchored bytes.
@@ -68,7 +68,7 @@ When running multiple delegations, normalize reported blockers by phase, command
 
 The `delegate` and `delegatePipeline` MCP calls are synchronous. Keep each call in the foreground until it returns; never hand it to Monitor or background execution.
 
-1. Call `delegate` through `mcp__plugin_claude-architect_runtime__delegate` with `checkoutPath`, the candidate spec, and `protocolVersion: "1.2.0"` copied from this skill's `PROTOCOL_VERSION` marker.
+1. Call `delegate` through `mcp__plugin_claude-architect_runtime__delegate` with `checkoutPath`, the candidate spec, and `protocolVersion: "1.3.0"` copied from this skill's `PROTOCOL_VERSION` marker.
 2. When it returns `ok:false` with `validationErrors`, repair only the reported spec defects and resubmit. This repair loop must not touch a Producer.
 3. When it returns a protocol/schema diagnostic, stop and tell the user to update the installed marketplace copy and reload Claude Code. Never guess across a version mismatch.
 4. When the result is `unavailable`, `failed`, or `cancelled`, report the structured classification and evidence. Do not claim a candidate exists. A Codex report with `laneEligibility.edit=false`, a missing `codex-native-sandbox`, or an unsupported Host is diagnostics-only and must not enter any legacy implementation lane.
@@ -99,7 +99,7 @@ edits).
    ```
 
 2. Call `mcp__plugin_claude-architect_runtime__delegatePipeline` with
-   `checkoutPath`, `spec`, `protocolVersion: "1.2.0"`.
+   `checkoutPath`, `spec`, `protocolVersion: "1.3.0"`.
 3. Read the returned evidence bundle: attempt result, per-round review
    reports and consolidated findings, fix dispositions, verification report,
    and gate reasons.

--- a/skills/delegate/SKILL.md
+++ b/skills/delegate/SKILL.md
@@ -115,6 +115,52 @@ edits).
 4. The pipeline never merges and never waives findings; you and the human
    remain the only decision-makers.
 
+## Sliced pipeline
+
+For a task that decomposes into ordered, independently testable steps, add a
+top-level `slices` array to the spec. Each slice is a scoped mini-spec with its
+own `objective`, `context`, `writeAllowlist`, `forbiddenScope`,
+`successCriteria`, and — required — its own `verification`:
+
+```yaml
+slices:
+  - objective: Add the parser for the new record type.
+    context: The record grammar lives in docs/format.md.
+    writeAllowlist: [src/parse/**]
+    forbiddenScope: [src/emit/**]
+    successCriteria:
+      - New record type round-trips through the parser.
+    verification:
+      - id: parse-tests
+        executable: npx
+        args: [vitest, run, tests/parse]
+        cwd: "."
+        timeoutMs: 600000
+        network: denied
+        expectedExitCodes: [0]
+  - objective: Emit the new record type.
+    # ...its own scope and verification
+```
+
+Slice rules and guarantees:
+
+- Each slice runs **fresh with no context** — a slice implementer sees only its
+  own mini-spec, never a prior slice's conversation, and is gated only by its
+  own `verification`. Each slice's `writeAllowlist` must be a subset of the
+  spec's, and its verification `cwd` must stay inside the candidate root.
+- A deterministic wayfinder routes each completed slice **advance / repair /
+  halt** from its verification result alone — no model judgment. A slice that
+  passes advances; a slice that fails is repaired within its round budget; a
+  slice that cannot be made to pass halts the run.
+- Review and the advisor judge the **composed candidate** at the end, over the
+  whole slice branch. Per-slice review is off by default; opt in with
+  `review.perSlice: true` to review each slice as it lands.
+- A mid-run halt yields a **partial** candidate with
+  `status: "human-decision-required"`, the halted slice index in
+  `haltedSliceIndex`, and each slice's route in `slices`. Present the completed
+  slices, the halt reason, and the partial candidate to the human; never accept
+  or continue past a halt on their behalf.
+
 ## Monitoring a backgrounded delegation
 
 `delegate` and `delegatePipeline` are synchronous, but the host auto-backgrounds

--- a/src/integrate/controlled-integrator.ts
+++ b/src/integrate/controlled-integrator.ts
@@ -1,13 +1,18 @@
 import { git, type GitResult } from "../git/git-exec.js";
 import { checkPreconditions } from "../git/repo-preconditions.js";
+import type { CheckoutLock, PlatformServices } from "../platform/platform-services.js";
 import { getPlatformServices } from "../platform/select-platform.js";
 import type { CandidateArtifact, ChangedPath } from "../protocol/attempt-result.js";
+import { RuntimeError } from "../util/errors.js";
 import { structuralVerify } from "../verify/structural-verifier.js";
 
 export interface ApplyCandidateTreeArgs {
   repoRoot: string;
   artifact: CandidateArtifact;
   expectedArtifactHash: string;
+  /** Trusted runtime handoff; never derived from candidate or MCP input. */
+  borrowedCheckoutLock?: CheckoutLock;
+  platformServices?: PlatformServices;
 }
 
 export interface IntegrationResult {
@@ -43,15 +48,23 @@ function statusMatchesArtifact(output: string, changedPaths: ChangedPath[]): boo
 }
 
 export async function applyCandidateTree(args: ApplyCandidateTreeArgs): Promise<IntegrationResult> {
-  const ps = getPlatformServices();
-  const { canonical } = await ps.canonicalizePath(args.repoRoot);
-  const lock = await ps.acquireCheckoutLock(canonical);
+  const ps = args.platformServices ?? getPlatformServices();
+  const canonicalPath = await ps.canonicalizePath(args.repoRoot);
+  const { canonical } = canonicalPath;
+  const repositoryIdentity = canonicalPath.gitCommonDir ?? canonicalPath.canonical;
+  let ownedLock: CheckoutLock | null = null;
+  const lock = args.borrowedCheckoutLock ?? await ps.acquireCheckoutLock(canonical);
+  if (args.borrowedCheckoutLock === undefined) ownedLock = lock;
   const terminal: { result: IntegrationResult | null } = { result: null };
   const finish = (result: IntegrationResult): IntegrationResult => {
     terminal.result = result;
     return result;
   };
   try {
+    if (lock.repositoryIdentity !== repositoryIdentity) {
+      const ownership = ownedLock === null ? "borrowed" : "owned";
+      throw new RuntimeError(`${ownership} checkout lease repository identity mismatch`);
+    }
     const preconditions = await checkPreconditions(canonical);
     if (!preconditions.ok) return finish(aborted(`precondition-failed:${preconditions.reason}`));
     if (preconditions.baseCommitOid !== args.artifact.baseCommitOid) {
@@ -145,11 +158,13 @@ export async function applyCandidateTree(args: ApplyCandidateTreeArgs): Promise<
     }
     return finish({ integration: "applied", detail: "candidate tree applied" });
   } finally {
-    try {
-      await lock.release();
-    } catch (error) {
-      if (terminal.result === null) throw error;
-      terminal.result.detail = `${terminal.result.detail}; checkout lock release failed`;
+    if (ownedLock !== null) {
+      try {
+        await ownedLock.release();
+      } catch (error) {
+        if (terminal.result === null) throw error;
+        terminal.result.detail = `${terminal.result.detail}; checkout lock release failed`;
+      }
     }
   }
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -54,6 +54,8 @@ export const delegatePipelineOutput = z.object({
     verification: z.record(z.string(), z.unknown()).nullable(),
     gate: z.record(z.string(), z.unknown()),
     finalCandidateCommit: z.string(),
+    slices: z.array(z.record(z.string(), z.unknown())),
+    haltedSliceIndex: z.number().nullable(),
   }).optional(),
   validationErrors: z.array(z.object({ path: z.string(), message: z.string() })).optional(),
   diagnostic: z.string().optional(),

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { git as runGit } from "../git/git-exec.js";
 import { applyCandidateTree as applyTree } from "../integrate/controlled-integrator.js";
-import type { PlatformServices } from "../platform/platform-services.js";
+import type { CheckoutLock, PlatformServices } from "../platform/platform-services.js";
 import { getPlatformServices } from "../platform/select-platform.js";
 import {
   runPipeline as executePipeline,
@@ -83,9 +83,21 @@ function runtimeError(message: string, error: string): RuntimeError {
   return new RuntimeError(message, { toolError: error });
 }
 
+class LifecycleLockReleaseError extends AggregateError {
+  constructor(readonly primaryError: unknown, releaseError: unknown) {
+    const primaryMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
+    super(
+      [primaryError, releaseError],
+      `${primaryMessage}; checkout lock release failed`,
+    );
+    this.name = "LifecycleLockReleaseError";
+  }
+}
+
 function errorResult(error: unknown): ToolErrorResult {
-  const code = error instanceof RuntimeError && typeof error.detail?.toolError === "string"
-    ? error.detail.toolError
+  const classified = error instanceof LifecycleLockReleaseError ? error.primaryError : error;
+  const code = classified instanceof RuntimeError && typeof classified.detail?.toolError === "string"
+    ? classified.detail.toolError
     : "runtime-error";
   const diagnostic = error instanceof Error ? error.message : String(error);
   return { ok: false, error: code, diagnostic: redact(diagnostic) };
@@ -161,15 +173,49 @@ async function withCurrentArchivedRun<T>(
   checkoutPath: string,
   runId: string,
   deps: ToolDependencies,
-  fn: (run: ArchivedRun) => Promise<T>,
+  fn: (run: ArchivedRun, lock: CheckoutLock, ps: PlatformServices) => Promise<T>,
+  preserveResultOnReleaseFailure?: (result: T) => T,
 ): Promise<T> {
-  const canonical = await services(deps).canonicalizePath(checkoutPath);
+  const ps = services(deps);
+  const canonical = await ps.canonicalizePath(checkoutPath);
   const callerKey = canonical.gitCommonDir ?? canonical.canonical;
   return withRepoLock(callerKey, async () => {
-    const run = await loadArchivedRun(runId, deps);
-    requireMatchingRepository(run, callerKey);
-    return fn(run);
+    const lock = await ps.acquireCheckoutLock(canonical.canonical);
+    let action: { ok: true; result: T } | { ok: false; error: unknown };
+    try {
+      if (lock.repositoryIdentity !== callerKey) {
+        throw runtimeError(
+          "supplied checkout repository identity changed before checkout lease acquisition",
+          "run-checkout-mismatch",
+        );
+      }
+      const run = await loadArchivedRun(runId, deps);
+      requireMatchingRepository(run, lock.repositoryIdentity);
+      action = { ok: true, result: await fn(run, lock, ps) };
+    } catch (error) {
+      action = { ok: false, error };
+    }
+    try {
+      await lock.release();
+    } catch (releaseError) {
+      if (!action.ok) throw new LifecycleLockReleaseError(action.error, releaseError);
+      if (preserveResultOnReleaseFailure !== undefined) {
+        return preserveResultOnReleaseFailure(action.result);
+      }
+      throw releaseError;
+    }
+    if (!action.ok) throw action.error;
+    return action.result;
   });
+}
+
+async function requireInactivePipeline(run: ArchivedRun, runId: string): Promise<void> {
+  if (await run.store.readPipelineActiveMarker(runId) !== null) {
+    throw runtimeError(
+      "the delegation pipeline for this run is still active",
+      "pipeline-active",
+    );
+  }
 }
 
 function schemaCompatibility(input: unknown): { ok: true } | { ok: false; diagnostic: string } {
@@ -341,6 +387,7 @@ export async function handleReviewCandidate(
 > {
   try {
     return await withCurrentArchivedRun(checkoutPath, runId, deps, async run => {
+      await requireInactivePipeline(run, runId);
       const candidate = requireCandidate(run);
       const git = deps.git ?? runGit;
       const anchor = await git(run.repoRoot, [
@@ -396,38 +443,27 @@ export async function handleDecideCandidate(
 ): Promise<{ recorded: true } | ToolErrorResult> {
   try {
     return await withCurrentArchivedRun(checkoutPath, runId, deps, async run => {
-      if (await run.store.readPipelineActiveMarker(runId) !== null) {
-        throw runtimeError(
-          "the delegation pipeline for this run is still active",
-          "pipeline-active",
-        );
-      }
+      await requireInactivePipeline(run, runId);
       if (decision === "accepted") requireVerifiedCandidate(run);
-      const ps = services(deps);
-      const lock = await ps.acquireCheckoutLock(run.repoRoot);
-      try {
-        const record: RunDecision = {
-          decision,
-          recordedAt: (deps.now ?? (() => new Date()))().toISOString(),
-        };
-        await run.store.writeDecision(record);
-        if (decision === "rejected" && run.result.candidate !== null) {
-          const candidate = run.result.candidate;
-          const deleted = await (deps.git ?? runGit)(run.repoRoot, [
-            "update-ref",
-            "--no-deref",
-            "-d",
-            candidate.anchorRef,
-            candidate.candidateCommitOid,
-          ]);
-          if (deleted.exitCode !== 0) {
-            throw runtimeError("failed to delete rejected candidate anchor", "anchor-delete-failed");
-          }
+      const record: RunDecision = {
+        decision,
+        recordedAt: (deps.now ?? (() => new Date()))().toISOString(),
+      };
+      await run.store.writeDecision(record);
+      if (decision === "rejected" && run.result.candidate !== null) {
+        const candidate = run.result.candidate;
+        const deleted = await (deps.git ?? runGit)(run.repoRoot, [
+          "update-ref",
+          "--no-deref",
+          "-d",
+          candidate.anchorRef,
+          candidate.candidateCommitOid,
+        ]);
+        if (deleted.exitCode !== 0) {
+          throw runtimeError("failed to delete rejected candidate anchor", "anchor-delete-failed");
         }
-        return { recorded: true };
-      } finally {
-        await lock.release();
       }
+      return { recorded: true };
     });
   } catch (error) {
     return errorResult(error);
@@ -441,13 +477,8 @@ export async function handleIntegrateCandidate(
   deps: ToolDependencies = {},
 ): Promise<{ integration: "applied" | "conflicted" | "aborted"; detail: string } | ToolErrorResult> {
   try {
-    return await withCurrentArchivedRun(checkoutPath, runId, deps, async run => {
-      if (await run.store.readPipelineActiveMarker(runId) !== null) {
-        throw runtimeError(
-          "the delegation pipeline for this run is still active",
-          "pipeline-active",
-        );
-      }
+    return await withCurrentArchivedRun(checkoutPath, runId, deps, async (run, lock, ps) => {
+      await requireInactivePipeline(run, runId);
       const decision = await run.store.readDecision(runId);
       if (decision?.decision !== "accepted") {
         return { integration: "aborted", detail: "no-accepted-decision" };
@@ -456,8 +487,13 @@ export async function handleIntegrateCandidate(
         repoRoot: run.repoRoot,
         artifact: requireVerifiedCandidate(run),
         expectedArtifactHash,
+        borrowedCheckoutLock: lock,
+        platformServices: ps,
       });
-    });
+    }, result => ({
+      ...result,
+      detail: `${result.detail}; checkout lock release failed`,
+    }));
   } catch (error) {
     return errorResult(error);
   }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -145,19 +145,31 @@ function requireVerifiedCandidate(run: ArchivedRun): CandidateArtifact {
   return requireCandidate(run);
 }
 
-async function requireMatchingCheckout(
+function requireMatchingRepository(
   run: ArchivedRun,
-  checkoutPath: string,
-  deps: ToolDependencies,
-): Promise<void> {
-  const canonical = await services(deps).canonicalizePath(checkoutPath);
-  const callerKey = canonical.gitCommonDir ?? canonical.canonical;
+  callerKey: string,
+): void {
   if (callerKey !== run.lockKey) {
     throw runtimeError(
       "candidate run belongs to a different repository than the supplied checkoutPath",
       "run-checkout-mismatch",
     );
   }
+}
+
+async function withCurrentArchivedRun<T>(
+  checkoutPath: string,
+  runId: string,
+  deps: ToolDependencies,
+  fn: (run: ArchivedRun) => Promise<T>,
+): Promise<T> {
+  const canonical = await services(deps).canonicalizePath(checkoutPath);
+  const callerKey = canonical.gitCommonDir ?? canonical.canonical;
+  return withRepoLock(callerKey, async () => {
+    const run = await loadArchivedRun(runId, deps);
+    requireMatchingRepository(run, callerKey);
+    return fn(run);
+  });
 }
 
 function schemaCompatibility(input: unknown): { ok: true } | { ok: false; diagnostic: string } {
@@ -328,9 +340,7 @@ export async function handleReviewCandidate(
   | ToolErrorResult
 > {
   try {
-    const run = await loadArchivedRun(runId, deps);
-    await requireMatchingCheckout(run, checkoutPath, deps);
-    return await withRepoLock(run.lockKey, async () => {
+    return await withCurrentArchivedRun(checkoutPath, runId, deps, async run => {
       const candidate = requireCandidate(run);
       const git = deps.git ?? runGit;
       const anchor = await git(run.repoRoot, [
@@ -385,9 +395,7 @@ export async function handleDecideCandidate(
   deps: ToolDependencies = {},
 ): Promise<{ recorded: true } | ToolErrorResult> {
   try {
-    const run = await loadArchivedRun(runId, deps);
-    await requireMatchingCheckout(run, checkoutPath, deps);
-    return await withRepoLock(run.lockKey, async () => {
+    return await withCurrentArchivedRun(checkoutPath, runId, deps, async run => {
       if (await run.store.readPipelineActiveMarker(runId) !== null) {
         throw runtimeError(
           "the delegation pipeline for this run is still active",
@@ -433,9 +441,7 @@ export async function handleIntegrateCandidate(
   deps: ToolDependencies = {},
 ): Promise<{ integration: "applied" | "conflicted" | "aborted"; detail: string } | ToolErrorResult> {
   try {
-    const run = await loadArchivedRun(runId, deps);
-    await requireMatchingCheckout(run, checkoutPath, deps);
-    return await withRepoLock(run.lockKey, async () => {
+    return await withCurrentArchivedRun(checkoutPath, runId, deps, async run => {
       if (await run.store.readPipelineActiveMarker(runId) !== null) {
         throw runtimeError(
           "the delegation pipeline for this run is still active",

--- a/src/pipeline/pipeline-runtime.ts
+++ b/src/pipeline/pipeline-runtime.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { git, type GitExecOptions, type GitResult } from "../git/git-exec.js";
 import { WorktreeManager } from "../git/worktree-manager.js";
+import type { PlatformServices } from "../platform/platform-services.js";
 import { getPlatformServices } from "../platform/select-platform.js";
 import type {
   CandidateArtifact,
@@ -21,6 +22,7 @@ import type { ProducerRegistry } from "../producers/producer-registry.js";
 import {
   runAttempt as defaultRunAttempt,
   type AttemptRuntimeDependencies,
+  type BorrowedCheckoutLease,
 } from "../runtime/attempt-runtime.js";
 import {
   ArtifactStore,
@@ -1123,10 +1125,50 @@ export async function runPipeline(
   spec: DelegationSpec,
   deps: PipelineDependencies,
 ): Promise<PipelineResult> {
+  const ps = deps.ps ?? getPlatformServices();
+  const canonical = await ps.canonicalizePath(checkoutPath);
+  const lock = await ps.acquireCheckoutLock(canonical.canonical);
+  const borrowedCheckoutLease: BorrowedCheckoutLease = {
+    lock,
+    repositoryIdentity: canonical.gitCommonDir ?? canonical.canonical,
+  };
+  let primaryError: unknown;
+  let hasPrimaryError = false;
+  try {
+    return await runPipelineWithLease(
+      checkoutPath,
+      spec,
+      deps,
+      ps,
+      borrowedCheckoutLease,
+    );
+  } catch (error) {
+    primaryError = error;
+    hasPrimaryError = true;
+    throw error;
+  } finally {
+    try {
+      await lock.release();
+    } catch (releaseError) {
+      if (!hasPrimaryError) throw releaseError;
+      throw new AggregateError(
+        [primaryError, releaseError],
+        "pipeline failed and its checkout lease could not be released",
+      );
+    }
+  }
+}
+
+async function runPipelineWithLease(
+  checkoutPath: string,
+  spec: DelegationSpec,
+  deps: PipelineDependencies,
+  ps: PlatformServices,
+  borrowedCheckoutLease: BorrowedCheckoutLease,
+): Promise<PipelineResult> {
   const runAttemptFn = deps.runAttempt ?? defaultRunAttempt;
   const slices = resolveSlices(spec);
   const initialSpec = slices.length === 0 ? spec : scopeSpecToSlice(spec, slices[0]!);
-  const ps = deps.ps ?? getPlatformServices();
   const activeOwner: PipelineActiveMarker = {
     pid: process.pid,
     processToken: await ps.getProcessStartToken(process.pid).catch(() => null),
@@ -1142,6 +1184,7 @@ export async function runPipeline(
   const inheritedOnRunStart = deps.onRunStart;
   const attempt = await runAttemptFn(checkoutPath, initialSpec, {
     ...deps,
+    borrowedCheckoutLease,
     async onRunStart(context) {
       runStart = context;
       if (slices.length > 0) {

--- a/src/pipeline/pipeline-runtime.ts
+++ b/src/pipeline/pipeline-runtime.ts
@@ -13,6 +13,7 @@ import {
   resolveReviewConfig,
   type DelegationSpec,
   type ReviewerKind,
+  type Slice,
 } from "../protocol/delegation-spec.js";
 import { loadSchemas } from "../protocol/schema-loader.js";
 import type { ProducerRegistry } from "../producers/producer-registry.js";
@@ -42,6 +43,7 @@ import type {
   VerificationReport,
 } from "./report-types.js";
 import type { PipelineRole, RolePackage } from "./role-prompts.js";
+import type { PipelineSlice } from "./slice-runner.js";
 import {
   runRole as defaultRunRole,
   type RoleRunArgs,
@@ -72,6 +74,8 @@ export interface PipelineResult {
   status: "decision-ready" | "human-decision-required" | "failed";
   attempt: AttemptResult;
   increments: PipelineIncrement[];
+  slices: PipelineSlice[];
+  haltedSliceIndex: number | null;
   rounds: PipelineRound[];
   verification: PipelineVerificationReport | null;
   gate: GateResult;
@@ -131,6 +135,12 @@ const IGNORED_STRUCTURAL_FAILURES = new Set<StructuralFailure>([
   "artifact-divergence",
   "base-changed",
 ]);
+
+export function scopeSpecToSlice(spec: DelegationSpec, slice: Slice): DelegationSpec {
+  const scoped = structuredClone({ ...spec, ...slice });
+  delete scoped.slices;
+  return scoped;
+}
 
 function gitFailure(action: string, result: GitResult): RuntimeError {
   const diagnostic = (result.stderr || result.stdout).trim().slice(0, 2_000);
@@ -287,12 +297,16 @@ function failedResult(
   reason: string,
   failure: FailureClassification = "producer-failure",
   increments: PipelineIncrement[] = [],
+  slices: PipelineSlice[] = [],
+  haltedSliceIndex: number | null = null,
 ): PipelineResult {
   return {
     runId: attempt.runId,
     status: "failed",
     attempt,
     increments,
+    slices,
+    haltedSliceIndex,
     rounds,
     verification: null,
     gate: {
@@ -393,6 +407,71 @@ async function candidateArtifact(args: {
   };
 }
 
+async function promoteFinalCandidate(args: {
+  checkoutPath: string;
+  attempt: AttemptResult;
+  initialCandidate: CandidateArtifact;
+  baselineCommit: string;
+  candidateCommit: string;
+  store: ArtifactStore;
+  privateObjectAccess?: LinkedWorktreeGitAccess;
+}): Promise<{ attempt: AttemptResult; candidateCommit: string } | null> {
+  let canonicalCommit: string;
+  try {
+    const objectReadOptions = args.privateObjectAccess === undefined
+      ? undefined
+      : privateObjectReadOptions(args.privateObjectAccess);
+    const finalTree = (await checkedGit(
+      args.checkoutPath,
+      ["rev-parse", `${args.candidateCommit}^{tree}`],
+      objectReadOptions,
+    )).trim();
+    canonicalCommit = (await checkedGit(args.checkoutPath, [
+      "commit-tree",
+      finalTree,
+      "-p",
+      args.baselineCommit,
+      "-m",
+      `candidate ${args.attempt.runId}`,
+    ], objectReadOptions)).trim();
+    if (args.privateObjectAccess !== undefined) {
+      await importPromotedObjects({
+        checkoutPath: args.checkoutPath,
+        baselineCommit: args.baselineCommit,
+        promotedCommit: canonicalCommit,
+        access: args.privateObjectAccess,
+      });
+    }
+  } catch {
+    return null;
+  }
+  await checkedGit(args.checkoutPath, [
+    "update-ref",
+    args.initialCandidate.anchorRef,
+    canonicalCommit,
+    args.initialCandidate.candidateCommitOid,
+  ]);
+  const diffText = await checkedGit(
+    args.checkoutPath,
+    ["diff", `${args.baselineCommit}..${canonicalCommit}`],
+  );
+  const candidate = await candidateArtifact({
+    worktreePath: args.checkoutPath,
+    baselineCommit: args.baselineCommit,
+    candidateCommit: canonicalCommit,
+    anchorRef: args.initialCandidate.anchorRef,
+    diffText,
+  });
+  const manifest = await args.store.readManifest(args.attempt.runId);
+  if (manifest === null) throw new RuntimeError("run manifest is missing during promotion");
+  const finalAttempt = { ...args.attempt, candidate };
+  await args.store.promoteTerminalArtifacts({
+    result: finalAttempt,
+    manifest: { ...manifest, candidateManifestHash: candidate.manifestHash },
+  });
+  return { attempt: finalAttempt, candidateCommit: canonicalCommit };
+}
+
 export function detectWeakenedTests(diff: string): { testsDeleted: number; testsSkipped: number } {
   let testsDeleted = 0;
   let testsSkipped = 0;
@@ -410,7 +489,7 @@ export function detectWeakenedTests(diff: string): { testsDeleted: number; tests
   return { testsDeleted, testsSkipped };
 }
 
-async function runReviews(args: {
+export async function runReviews(args: {
   reviewers: ReviewerKind[];
   spec: DelegationSpec;
   pkg: RolePackage;
@@ -419,13 +498,17 @@ async function runReviews(args: {
   runId: string;
   round: number;
   store: ArtifactStore;
+  logNameNamespace?: string;
 }): Promise<ReviewRunResult> {
+  const logNameNamespace = args.logNameNamespace === undefined
+    ? ""
+    : `${args.logNameNamespace}-`;
   const outcomes = await Promise.all(args.reviewers.map(async reviewer => {
     const role = `reviewer-${reviewer}` as const;
     const outcome = await runStructuredRole<ReviewReport>({
       role,
       schema: schemas.reviewReport,
-      logName: `role-${role}-round${args.round}`,
+      logName: `role-${role}-${logNameNamespace}round${args.round}`,
       spec: args.spec,
       pkg: args.pkg,
       worktreePath: args.worktreePath,
@@ -480,7 +563,7 @@ async function runFix(args: {
     : outcome;
 }
 
-async function runIncrement(args: {
+export async function runIncrement(args: {
   spec: DelegationSpec;
   pkg: RolePackage;
   worktreePath: string;
@@ -490,11 +573,15 @@ async function runIncrement(args: {
   store: ArtifactStore;
   gitObjectAccess: LinkedWorktreeGitAccess;
   runStart?: RunStartContext;
+  logNameNamespace?: string;
 }): Promise<StructuredRoleRunResult<IncrementReport>> {
+  const logNameNamespace = args.logNameNamespace === undefined
+    ? ""
+    : `${args.logNameNamespace}-`;
   return runStructuredRole<IncrementReport>({
     role: "implementer",
     schema: schemas.incrementReport,
-    logName: `role-implementer-increment${args.increment}`,
+    logName: `role-implementer-${logNameNamespace}increment${args.increment}`,
     spec: args.spec,
     pkg: args.pkg,
     worktreePath: args.worktreePath,
@@ -629,7 +716,7 @@ async function validateFixProvenance(args: {
   return null;
 }
 
-async function verifyCandidate(args: {
+export async function verifyCandidate(args: {
   checkoutPath: string;
   spec: DelegationSpec;
   deps: PipelineDependencies;
@@ -637,11 +724,13 @@ async function verifyCandidate(args: {
   baselineCommit: string;
   candidateCommit: string;
   store: ArtifactStore;
+  namespace?: string;
 }): Promise<{ verification: PipelineVerificationReport; baselineDrift: boolean }> {
   const ps = args.deps.ps ?? getPlatformServices();
+  const namespace = args.namespace === undefined ? "" : `${args.namespace}-`;
   const manager = new WorktreeManager(
     args.checkoutPath,
-    `${args.attempt.runId}-verify`,
+    `${args.attempt.runId}-${namespace}verify`,
     ps,
   );
   const fresh = await manager.create(args.candidateCommit);
@@ -686,8 +775,8 @@ async function verifyCandidate(args: {
       spec: args.spec,
       ps,
       artifactStore: args.store,
-      verificationId: () => `${args.attempt.runId}-pipeline`,
-      logNamePrefix: "pipeline-verification",
+      verificationId: () => `${args.attempt.runId}-${namespace}pipeline`,
+      logNamePrefix: `${namespace}pipeline-verification`,
     });
     const changedPaths = nameOnly.split("\n").map(line => line.trim()).filter(Boolean);
     const scopeViolations = changedPaths.filter(pathname =>
@@ -1068,29 +1157,16 @@ export async function runPipeline(
             increments,
           );
         }
-        let canonicalCommit: string;
-        try {
-          const privateObjects = privateObjectReadOptions(gitObjectAccess);
-          const finalTree = (await checkedGit(
-            checkoutPath,
-            ["rev-parse", `${currentCandidateCommit}^{tree}`],
-            privateObjects,
-          )).trim();
-          canonicalCommit = (await checkedGit(checkoutPath, [
-            "commit-tree",
-            finalTree,
-            "-p",
-            baselineCommit,
-            "-m",
-            `candidate ${attempt.runId}`,
-          ], privateObjects)).trim();
-          await importPromotedObjects({
-            checkoutPath,
-            baselineCommit,
-            promotedCommit: canonicalCommit,
-            access: gitObjectAccess,
-          });
-        } catch {
+        const promoted = await promoteFinalCandidate({
+          checkoutPath,
+          attempt,
+          initialCandidate: attempt.candidate,
+          baselineCommit,
+          candidateCommit: currentCandidateCommit,
+          store,
+          privateObjectAccess: gitObjectAccess,
+        });
+        if (promoted === null) {
           return failedResult(
             attempt,
             rounds,
@@ -1100,31 +1176,8 @@ export async function runPipeline(
             increments,
           );
         }
-        await checkedGit(checkoutPath, [
-          "update-ref",
-          attempt.candidate.anchorRef,
-          canonicalCommit,
-          attempt.candidate.candidateCommitOid,
-        ]);
-        currentCandidateCommit = canonicalCommit;
-        const diffText = await checkedGit(
-          checkoutPath,
-          ["diff", `${baselineCommit}..${canonicalCommit}`],
-        );
-        const candidate = await candidateArtifact({
-          worktreePath: checkoutPath,
-          baselineCommit,
-          candidateCommit: canonicalCommit,
-          anchorRef: attempt.candidate.anchorRef,
-          diffText,
-        });
-        const manifest = await store.readManifest(attempt.runId);
-        if (manifest === null) throw new RuntimeError("run manifest is missing during promotion");
-        finalAttempt = { ...attempt, candidate };
-        await store.promoteTerminalArtifacts({
-          result: finalAttempt,
-          manifest: { ...manifest, candidateManifestHash: candidate.manifestHash },
-        });
+        finalAttempt = promoted.attempt;
+        currentCandidateCommit = promoted.candidateCommit;
       }
     } catch (error) {
       primaryError = error;
@@ -1170,6 +1223,8 @@ export async function runPipeline(
       status: gate.decisionReady ? "decision-ready" : "human-decision-required",
       attempt: finalAttempt,
       increments,
+      slices: [],
+      haltedSliceIndex: null,
       rounds,
       verification: verified.verification,
       gate,

--- a/src/pipeline/pipeline-runtime.ts
+++ b/src/pipeline/pipeline-runtime.ts
@@ -139,6 +139,12 @@ const IGNORED_STRUCTURAL_FAILURES = new Set<StructuralFailure>([
   "artifact-divergence",
   "base-changed",
 ]);
+const SLICE_REF_PREFIX = "refs/claude-architect/slices/";
+
+interface TemporarySliceRef {
+  ref: string;
+  oid: string;
+}
 
 export function scopeSpecToSlice(spec: DelegationSpec, slice: Slice): DelegationSpec {
   const scoped = structuredClone({ ...spec, ...slice });
@@ -159,6 +165,48 @@ async function checkedGit(
   const result = await git(cwd, args, options);
   if (result.exitCode !== 0) throw gitFailure(`git ${args[0] ?? "command"}`, result);
   return result.stdout;
+}
+
+function temporarySliceRef(runId: string, index: number, attempt: number): string {
+  return `${SLICE_REF_PREFIX}${runId}/slice-${index}-attempt-${attempt}`;
+}
+
+async function createTemporarySliceRef(
+  checkoutPath: string,
+  temporaryRef: TemporarySliceRef,
+): Promise<void> {
+  const result = await git(checkoutPath, [
+    "update-ref",
+    "--no-deref",
+    temporaryRef.ref,
+    temporaryRef.oid,
+    "0".repeat(temporaryRef.oid.length),
+  ]);
+  if (result.exitCode !== 0) throw gitFailure("create temporary slice ref", result);
+}
+
+async function cleanupTemporarySliceRefs(
+  checkoutPath: string,
+  temporaryRefs: TemporarySliceRef[],
+): Promise<unknown[]> {
+  const errors: unknown[] = [];
+  for (const temporaryRef of [...temporaryRefs].reverse()) {
+    try {
+      const result = await git(checkoutPath, [
+        "update-ref",
+        "--no-deref",
+        "-d",
+        temporaryRef.ref,
+        temporaryRef.oid,
+      ]);
+      if (result.exitCode !== 0) {
+        errors.push(gitFailure("delete temporary slice ref", result));
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  return errors;
 }
 
 function privateObjectReadOptions(access: LinkedWorktreeGitAccess): GitExecOptions {
@@ -389,6 +437,73 @@ class SliceExecutionError extends RuntimeError {
   constructor(message: string, readonly failure: FailureClassification) {
     super(message);
     this.name = "SliceExecutionError";
+  }
+}
+
+function findSliceExecutionError(error: unknown): SliceExecutionError | null {
+  if (error instanceof SliceExecutionError) return error;
+  if (!(error instanceof AggregateError)) return null;
+  for (const nested of error.errors) {
+    const found = findSliceExecutionError(nested);
+    if (found !== null) return found;
+  }
+  return null;
+}
+
+function failedAttemptStatus(failure: FailureClassification): AttemptResult["status"] {
+  if (failure === "unavailable" || failure === "authentication-required") return "unavailable";
+  if (failure === "cancelled") return "cancelled";
+  return "failed";
+}
+
+async function archiveSlicedFailure(args: {
+  attempt: AttemptResult;
+  failure: FailureClassification;
+  reason: string;
+  store: ArtifactStore;
+}): Promise<AttemptResult> {
+  const failedAttempt: AttemptResult = {
+    ...args.attempt,
+    status: failedAttemptStatus(args.failure),
+    failure: args.failure,
+    summary: args.reason,
+    candidate: args.failure === "verification-failure" ? args.attempt.candidate : null,
+    unresolvedIssues: [...args.attempt.unresolvedIssues, args.reason],
+    evidence: {
+      ...args.attempt.evidence,
+      pipelineFailure: { failure: args.failure, reason: args.reason },
+    },
+  };
+  const manifest = await args.store.readManifest(args.attempt.runId);
+  if (manifest === null) {
+    throw new RuntimeError("run manifest is missing while archiving sliced failure");
+  }
+  await args.store.promoteTerminalArtifacts({ result: failedAttempt, manifest });
+  return failedAttempt;
+}
+
+async function archiveSliceExecutionError(args: {
+  error: unknown;
+  attempt: AttemptResult;
+  store: ArtifactStore;
+}): Promise<{ sliceError: SliceExecutionError; failedAttempt: AttemptResult }> {
+  const sliceError = findSliceExecutionError(args.error);
+  if (sliceError === null) throw args.error;
+  try {
+    return {
+      sliceError,
+      failedAttempt: await archiveSlicedFailure({
+        attempt: args.attempt,
+        failure: sliceError.failure,
+        reason: sliceError.message,
+        store: args.store,
+      }),
+    };
+  } catch (archiveError) {
+    throw new AggregateError(
+      [args.error, archiveError],
+      "sliced pipeline failed and its attempt result could not be archived",
+    );
   }
 }
 
@@ -733,7 +848,9 @@ async function validateCandidateProvenance(args: {
   previousCandidateCommit: string;
   candidateCommit: string;
   gitObjectAccess: LinkedWorktreeGitAccess;
+  phaseLabel?: string;
 }): Promise<CandidateProvenanceFailure | null> {
+  const phaseLabel = args.phaseLabel ?? "fix phase";
   const privateObjects = privateObjectReadOptions(args.gitObjectAccess);
   const candidateObject = await git(args.worktreePath, [
     "cat-file",
@@ -743,7 +860,7 @@ async function validateCandidateProvenance(args: {
   if (candidateObject.exitCode !== 0) {
     return {
       failure: "producer-failure",
-      reason: "fix phase reported a missing candidate commit",
+      reason: `${phaseLabel} reported a missing candidate commit`,
     };
   }
 
@@ -755,7 +872,7 @@ async function validateCandidateProvenance(args: {
   if (head.exitCode !== 0 || head.stdout.trim() !== args.candidateCommit) {
     return {
       failure: "producer-failure",
-      reason: "fix phase reported a candidate commit that does not match its worktree HEAD",
+      reason: `${phaseLabel} reported a candidate commit that does not match its worktree HEAD`,
     };
   }
 
@@ -768,7 +885,7 @@ async function validateCandidateProvenance(args: {
   if (candidateAncestry.exitCode !== 0) {
     return {
       failure: "sandbox-violation",
-      reason: "fix phase candidate commit is not descended from the reviewed candidate",
+      reason: `${phaseLabel} candidate commit is not descended from the reviewed candidate`,
     };
   }
 
@@ -780,13 +897,13 @@ async function validateCandidateProvenance(args: {
   if (worktreeStatus.exitCode !== 0) {
     return {
       failure: "sandbox-violation",
-      reason: "fix phase candidate worktree cleanliness could not be verified",
+      reason: `${phaseLabel} candidate worktree cleanliness could not be verified`,
     };
   }
   if (worktreeStatus.stdout.length > 0) {
     return {
       failure: "sandbox-violation",
-      reason: "fix phase candidate worktree contains uncommitted state",
+      reason: `${phaseLabel} candidate worktree contains uncommitted state`,
     };
   }
 
@@ -1006,6 +1123,8 @@ export async function runPipeline(
     startedAt: new Date().toISOString(),
   };
   await store.writePipelineActiveMarker(activeOwner);
+  const temporarySliceRefs: TemporarySliceRef[] = [];
+  let finalAttempt = attempt;
   let pipelinePrimaryError: unknown;
   try {
     const reviewConfig = resolveReviewConfig(spec);
@@ -1013,7 +1132,6 @@ export async function runPipeline(
     const maxIncrements = slices.length === 0
       ? resolveImplementationConfig(spec).maxIncrements
       : 1;
-    let finalAttempt = attempt;
     const increments: PipelineIncrement[] = [];
     let incrementOutcome: IncrementOutcome | undefined;
     const rounds: PipelineRound[] = [];
@@ -1021,6 +1139,33 @@ export async function runPipeline(
     let currentCandidateCommit = attempt.candidate.candidateCommitOid;
     let frozenTestEvidence = testEvidence(attempt);
     let pipelineSlices: PipelineSlice[] = [];
+    const archivePipelineFailure = async (args: {
+      finalCandidateCommit: string;
+      reason: string;
+      failure: FailureClassification;
+      slices?: PipelineSlice[];
+      haltedSliceIndex?: number | null;
+    }): Promise<PipelineResult> => {
+      const failedAttempt = slices.length === 0
+        ? attempt
+        : await archiveSlicedFailure({
+          attempt,
+          failure: args.failure,
+          reason: args.reason,
+          store,
+        });
+      finalAttempt = failedAttempt;
+      return failedResult(
+        failedAttempt,
+        rounds,
+        args.finalCandidateCommit,
+        args.reason,
+        args.failure,
+        increments,
+        args.slices ?? pipelineSlices,
+        args.haltedSliceIndex ?? null,
+      );
+    };
 
     if (slices.length > 0) {
       const initialNamespace = "slice-1-attempt-0";
@@ -1037,18 +1182,35 @@ export async function runPipeline(
       let initialPerSliceReview: ConsolidationResult | null = null;
       const initialRoleLogRefs = attemptLogRefs(attempt);
       if (reviewConfig.perSlice === true) {
-        const reviewed = await runSliceReview({
-          checkoutPath,
-          spec: initialSpec,
-          deps,
-          runId: attempt.runId,
-          baselineCommit,
-          candidateCommit: currentCandidateCommit,
-          namespace: initialNamespace,
-          reviewers,
-          verification: initialVerification.verification,
-          store,
-        });
+        let reviewed;
+        try {
+          reviewed = await runSliceReview({
+            checkoutPath,
+            spec: initialSpec,
+            deps,
+            runId: attempt.runId,
+            baselineCommit,
+            candidateCommit: currentCandidateCommit,
+            namespace: initialNamespace,
+            reviewers,
+            verification: initialVerification.verification,
+            store,
+          });
+        } catch (error) {
+          const archived = await archiveSliceExecutionError({ error, attempt, store });
+          finalAttempt = archived.failedAttempt;
+          if (error !== archived.sliceError) throw error;
+          const failed = failedResult(
+            archived.failedAttempt,
+            rounds,
+            baselineCommit,
+            archived.sliceError.message,
+            archived.sliceError.failure,
+            increments,
+          );
+          await store.writePipelineArtifact("pipeline-result", failed);
+          return failed;
+        }
         initialPerSliceReview = reviewed.review;
         initialRoleLogRefs.push(...reviewed.roleLogRefs);
       }
@@ -1119,6 +1281,7 @@ export async function runPipeline(
                   previousCandidateCommit: base,
                   candidateCommit,
                   gitObjectAccess,
+                  phaseLabel: "slice implementer",
                 });
                 if (provenanceFailure !== null) {
                   throw new SliceExecutionError(
@@ -1140,6 +1303,19 @@ export async function runPipeline(
                       "sandbox-violation",
                     );
                   }
+                  const temporaryRef = {
+                    ref: temporarySliceRef(attempt.runId, index, sliceAttempt),
+                    oid: candidateCommit,
+                  };
+                  try {
+                    await createTemporarySliceRef(checkoutPath, temporaryRef);
+                  } catch {
+                    throw new SliceExecutionError(
+                      "slice candidate temporary ref could not be established",
+                      "sandbox-violation",
+                    );
+                  }
+                  temporarySliceRefs.push(temporaryRef);
                 }
 
                 const verified = await verifyCandidate({
@@ -1189,13 +1365,15 @@ export async function runPipeline(
           },
         });
       } catch (error) {
-        if (!(error instanceof SliceExecutionError)) throw error;
+        const archived = await archiveSliceExecutionError({ error, attempt, store });
+        finalAttempt = archived.failedAttempt;
+        if (error !== archived.sliceError) throw error;
         const failed = failedResult(
-          attempt,
+          archived.failedAttempt,
           rounds,
           completedSlices.at(-1)?.candidateCommit ?? baselineCommit,
-          error.message,
-          error.failure,
+          archived.sliceError.message,
+          archived.sliceError.failure,
           increments,
           completedSlices,
         );
@@ -1206,11 +1384,19 @@ export async function runPipeline(
       currentCandidateCommit = phase.finalCandidateCommit;
       if (phase.haltedSliceIndex !== null) {
         const halted = phase.slices.at(-1);
-        const failed = failedResult(
+        const reason = `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`;
+        const failedAttempt = await archiveSlicedFailure({
           attempt,
+          failure: "verification-failure",
+          reason,
+          store,
+        });
+        finalAttempt = failedAttempt;
+        const failed = failedResult(
+          failedAttempt,
           rounds,
           currentCandidateCommit,
-          `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`,
+          reason,
           "verification-failure",
           increments,
           phase.slices,
@@ -1395,15 +1581,12 @@ export async function runPipeline(
           store,
         });
         if (!reviewRun.ok) {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            `review phase did not produce valid structured output (see ${reviewRun.failedRoleLogRef})`,
-            "producer-failure",
-            increments,
-            pipelineSlices,
-          );
+          const reason = `review phase did not produce valid structured output (see ${reviewRun.failedRoleLogRef})`;
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason,
+            failure: "producer-failure",
+          });
         }
 
         const reviews = reviewRun.reviews.map(review => ({
@@ -1429,15 +1612,11 @@ export async function runPipeline(
         try {
           gitObjectAccess ??= await resolveLinkedWorktreeWritableRoots(candidateWorktree.path);
         } catch {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            "fixer git object isolation could not be established",
-            "sandbox-violation",
-            increments,
-            pipelineSlices,
-          );
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason: "fixer git object isolation could not be established",
+            failure: "sandbox-violation",
+          });
         }
 
         notePhase(`round ${round}: applying fixes`);
@@ -1453,15 +1632,11 @@ export async function runPipeline(
           ...(runStart === undefined ? {} : { runStart }),
         });
         if (!fixRun.ok) {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            `fix phase did not produce valid structured output (see ${fixRun.failedRoleLogRef})`,
-            fixRun.failure,
-            increments,
-            pipelineSlices,
-          );
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason: `fix phase did not produce valid structured output (see ${fixRun.failedRoleLogRef})`,
+            failure: fixRun.failure,
+          });
         }
         const { fix } = fixRun;
         await store.writePipelineArtifact(`round-${round}-fix`, fix);
@@ -1472,15 +1647,11 @@ export async function runPipeline(
           gitObjectAccess,
         });
         if (provenanceFailure !== null) {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            provenanceFailure.reason,
-            provenanceFailure.failure,
-            increments,
-            pipelineSlices,
-          );
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason: provenanceFailure.reason,
+            failure: provenanceFailure.failure,
+          });
         }
         currentCandidateCommit = fix.candidateCommit;
         rounds.push({
@@ -1514,17 +1685,13 @@ export async function runPipeline(
           ...(gitObjectAccess === null ? {} : { privateObjectAccess: gitObjectAccess }),
         });
         if (promoted === null) {
-          return failedResult(
-            attempt,
-            rounds,
-            currentCandidateCommit,
-            slices.length === 0
+          return await archivePipelineFailure({
+            finalCandidateCommit: currentCandidateCommit,
+            reason: slices.length === 0
               ? "fixer objects could not be imported into the shared git object store"
               : "sliced candidate could not be promoted from the shared git object store",
-            "sandbox-violation",
-            increments,
-            pipelineSlices,
-          );
+            failure: "sandbox-violation",
+          });
         }
         finalAttempt = promoted.attempt;
         currentCandidateCommit = promoted.candidateCommit;
@@ -1585,17 +1752,55 @@ export async function runPipeline(
     await store.writePipelineArtifact("pipeline-result", result);
     return result;
   } catch (error) {
-    pipelinePrimaryError = error;
-    throw error;
+    let terminalError = error;
+    if (slices.length > 0 && finalAttempt.status === "verified-candidate") {
+      try {
+        finalAttempt = await archiveSlicedFailure({
+          attempt: finalAttempt,
+          failure: "verification-failure",
+          reason: "sliced pipeline terminated before completing trusted gates",
+          store,
+        });
+      } catch (archiveError) {
+        terminalError = new AggregateError(
+          [error, archiveError],
+          "sliced pipeline failed and its attempt result could not be archived",
+        );
+      }
+    }
+    pipelinePrimaryError = terminalError;
+    throw terminalError;
   } finally {
-    try {
-      await store.clearPipelineActiveMarker();
-    } catch (cleanupError) {
-      if (pipelinePrimaryError === undefined) throw cleanupError;
-      throw new AggregateError(
-        [pipelinePrimaryError, cleanupError],
-        "pipeline failed and its active marker could not be cleared",
-      );
+    const cleanupErrors = await cleanupTemporarySliceRefs(checkoutPath, temporarySliceRefs);
+    let canClearActiveMarker = true;
+    if (cleanupErrors.length > 0
+      && slices.length > 0
+      && finalAttempt.status === "verified-candidate") {
+      try {
+        finalAttempt = await archiveSlicedFailure({
+          attempt: finalAttempt,
+          failure: "verification-failure",
+          reason: "temporary slice ref cleanup did not complete",
+          store,
+        });
+      } catch (archiveError) {
+        cleanupErrors.push(archiveError);
+        canClearActiveMarker = false;
+      }
+    }
+    if (canClearActiveMarker) {
+      try {
+        await store.clearPipelineActiveMarker();
+      } catch (cleanupError) {
+        cleanupErrors.push(cleanupError);
+      }
+    }
+    if (cleanupErrors.length > 0) {
+      const errors = pipelinePrimaryError === undefined
+        ? cleanupErrors
+        : [pipelinePrimaryError, ...cleanupErrors];
+      if (errors.length === 1) throw errors[0];
+      throw new AggregateError(errors, "pipeline failed or its terminal cleanup was incomplete");
     }
   }
 }

--- a/src/pipeline/pipeline-runtime.ts
+++ b/src/pipeline/pipeline-runtime.ts
@@ -139,6 +139,7 @@ const IGNORED_STRUCTURAL_FAILURES = new Set<StructuralFailure>([
   "artifact-divergence",
   "base-changed",
 ]);
+const CANDIDATE_REF_PREFIX = "refs/claude-architect/candidates/";
 const SLICE_REF_PREFIX = "refs/claude-architect/slices/";
 
 interface TemporarySliceRef {
@@ -440,6 +441,13 @@ class SliceExecutionError extends RuntimeError {
   }
 }
 
+class SlicedFailureArchiveError extends RuntimeError {
+  constructor(readonly cause: unknown) {
+    super(cause instanceof Error ? cause.message : "sliced failure archival failed");
+    this.name = "SlicedFailureArchiveError";
+  }
+}
+
 function findSliceExecutionError(error: unknown): SliceExecutionError | null {
   if (error instanceof SliceExecutionError) return error;
   if (!(error instanceof AggregateError)) return null;
@@ -450,6 +458,12 @@ function findSliceExecutionError(error: unknown): SliceExecutionError | null {
   return null;
 }
 
+function containsSlicedFailureArchiveError(error: unknown): boolean {
+  if (error instanceof SlicedFailureArchiveError) return true;
+  if (!(error instanceof AggregateError)) return false;
+  return error.errors.some(containsSlicedFailureArchiveError);
+}
+
 function failedAttemptStatus(failure: FailureClassification): AttemptResult["status"] {
   if (failure === "unavailable" || failure === "authentication-required") return "unavailable";
   if (failure === "cancelled") return "cancelled";
@@ -457,32 +471,55 @@ function failedAttemptStatus(failure: FailureClassification): AttemptResult["sta
 }
 
 async function archiveSlicedFailure(args: {
+  checkoutPath: string;
   attempt: AttemptResult;
   failure: FailureClassification;
   reason: string;
   store: ArtifactStore;
 }): Promise<AttemptResult> {
-  const failedAttempt: AttemptResult = {
-    ...args.attempt,
-    status: failedAttemptStatus(args.failure),
-    failure: args.failure,
-    summary: args.reason,
-    candidate: args.failure === "verification-failure" ? args.attempt.candidate : null,
-    unresolvedIssues: [...args.attempt.unresolvedIssues, args.reason],
-    evidence: {
-      ...args.attempt.evidence,
-      pipelineFailure: { failure: args.failure, reason: args.reason },
-    },
-  };
-  const manifest = await args.store.readManifest(args.attempt.runId);
-  if (manifest === null) {
-    throw new RuntimeError("run manifest is missing while archiving sliced failure");
+  try {
+    const manifest = await args.store.readManifest(args.attempt.runId);
+    if (manifest === null) {
+      throw new RuntimeError("run manifest is missing while archiving sliced failure");
+    }
+    const retainCandidate = args.failure === "verification-failure";
+    if (!retainCandidate && args.attempt.candidate !== null) {
+      const candidate = args.attempt.candidate;
+      const expectedRef = `${CANDIDATE_REF_PREFIX}${args.attempt.runId}`;
+      if (candidate.anchorRef !== expectedRef) {
+        throw new RuntimeError("sliced candidate anchor does not match run id");
+      }
+      const deleted = await git(args.checkoutPath, [
+        "update-ref",
+        "--no-deref",
+        "-d",
+        candidate.anchorRef,
+        candidate.candidateCommitOid,
+      ]);
+      if (deleted.exitCode !== 0) throw gitFailure("delete sliced candidate anchor", deleted);
+    }
+    const failedAttempt: AttemptResult = {
+      ...args.attempt,
+      status: failedAttemptStatus(args.failure),
+      failure: args.failure,
+      summary: args.reason,
+      candidate: retainCandidate ? args.attempt.candidate : null,
+      unresolvedIssues: [...args.attempt.unresolvedIssues, args.reason],
+      evidence: {
+        ...args.attempt.evidence,
+        pipelineFailure: { failure: args.failure, reason: args.reason },
+      },
+    };
+    await args.store.promoteTerminalArtifacts({ result: failedAttempt, manifest });
+    return failedAttempt;
+  } catch (error) {
+    if (error instanceof SlicedFailureArchiveError) throw error;
+    throw new SlicedFailureArchiveError(error);
   }
-  await args.store.promoteTerminalArtifacts({ result: failedAttempt, manifest });
-  return failedAttempt;
 }
 
 async function archiveSliceExecutionError(args: {
+  checkoutPath: string;
   error: unknown;
   attempt: AttemptResult;
   store: ArtifactStore;
@@ -493,6 +530,7 @@ async function archiveSliceExecutionError(args: {
     return {
       sliceError,
       failedAttempt: await archiveSlicedFailure({
+        checkoutPath: args.checkoutPath,
         attempt: args.attempt,
         failure: sliceError.failure,
         reason: sliceError.message,
@@ -1157,6 +1195,7 @@ export async function runPipeline(
       const failedAttempt = slices.length === 0
         ? attempt
         : await archiveSlicedFailure({
+          checkoutPath,
           attempt,
           failure: args.failure,
           reason: args.reason,
@@ -1206,7 +1245,12 @@ export async function runPipeline(
             store,
           });
         } catch (error) {
-          const archived = await archiveSliceExecutionError({ error, attempt, store });
+          const archived = await archiveSliceExecutionError({
+            checkoutPath,
+            error,
+            attempt,
+            store,
+          });
           authoritySafeToRelease = true;
           finalAttempt = archived.failedAttempt;
           if (error !== archived.sliceError) throw error;
@@ -1375,7 +1419,12 @@ export async function runPipeline(
           },
         });
       } catch (error) {
-        const archived = await archiveSliceExecutionError({ error, attempt, store });
+        const archived = await archiveSliceExecutionError({
+          checkoutPath,
+          error,
+          attempt,
+          store,
+        });
         authoritySafeToRelease = true;
         finalAttempt = archived.failedAttempt;
         if (error !== archived.sliceError) throw error;
@@ -1397,6 +1446,7 @@ export async function runPipeline(
         const halted = phase.slices.at(-1);
         const reason = `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`;
         const failedAttempt = await archiveSlicedFailure({
+          checkoutPath,
           attempt,
           failure: "verification-failure",
           reason,
@@ -1766,9 +1816,12 @@ export async function runPipeline(
     return result;
   } catch (error) {
     let terminalError = error;
-    if (slices.length > 0 && finalAttempt.status === "verified-candidate") {
+    if (slices.length > 0
+      && finalAttempt.status === "verified-candidate"
+      && !containsSlicedFailureArchiveError(error)) {
       try {
         finalAttempt = await archiveSlicedFailure({
+          checkoutPath,
           attempt: finalAttempt,
           failure: "verification-failure",
           reason: "sliced pipeline terminated before completing trusted gates",
@@ -1788,9 +1841,11 @@ export async function runPipeline(
     const cleanupErrors = await cleanupTemporarySliceRefs(checkoutPath, temporarySliceRefs);
     if (cleanupErrors.length > 0
       && slices.length > 0
-      && finalAttempt.status === "verified-candidate") {
+      && finalAttempt.status === "verified-candidate"
+      && !containsSlicedFailureArchiveError(pipelinePrimaryError)) {
       try {
         finalAttempt = await archiveSlicedFailure({
+          checkoutPath,
           attempt: finalAttempt,
           failure: "verification-failure",
           reason: "temporary slice ref cleanup did not complete",

--- a/src/pipeline/pipeline-runtime.ts
+++ b/src/pipeline/pipeline-runtime.ts
@@ -1088,20 +1088,34 @@ export async function runPipeline(
   const runAttemptFn = deps.runAttempt ?? defaultRunAttempt;
   const slices = resolveSlices(spec);
   const initialSpec = slices.length === 0 ? spec : scopeSpecToSlice(spec, slices[0]!);
+  const ps = deps.ps ?? getPlatformServices();
+  const activeOwner: PipelineActiveMarker = {
+    pid: process.pid,
+    processToken: await ps.getProcessStartToken(process.pid).catch(() => null),
+    startedAt: new Date().toISOString(),
+    sliced: slices.length > 0,
+  };
   const notePhase = (phase: string): void => {
     // Best-effort progress; must never affect pipeline control flow.
     try { deps.onPhase?.(phase); } catch { /* progress reporting is advisory */ }
   };
   let runStart: RunStartContext | undefined;
+  let slicedMarkerEstablished = false;
   const inheritedOnRunStart = deps.onRunStart;
   const attempt = await runAttemptFn(checkoutPath, initialSpec, {
     ...deps,
-    onRunStart(context) {
+    async onRunStart(context) {
       runStart = context;
-      inheritedOnRunStart?.(context);
+      if (slices.length > 0) {
+        await new ArtifactStore(context.record.runId).writePipelineActiveMarker(activeOwner);
+        slicedMarkerEstablished = true;
+      }
+      await inheritedOnRunStart?.(context);
     },
   });
+  const store = new ArtifactStore(attempt.runId);
   if (attempt.status !== "verified-candidate" || attempt.candidate === null) {
+    if (slicedMarkerEstablished) await store.clearPipelineActiveMarker();
     // Propagate the attempt's own classification (e.g. verification-failure for a
     // base-changed candidate, timeout, sandbox-violation) instead of flattening
     // every non-verified implement phase to producer-failure. A blameless base
@@ -1115,16 +1129,10 @@ export async function runPipeline(
     );
   }
 
-  const store = new ArtifactStore(attempt.runId);
-  const ps = deps.ps ?? getPlatformServices();
-  const activeOwner: PipelineActiveMarker = {
-    pid: process.pid,
-    processToken: await ps.getProcessStartToken(process.pid).catch(() => null),
-    startedAt: new Date().toISOString(),
-  };
-  await store.writePipelineActiveMarker(activeOwner);
+  if (slices.length === 0) await store.writePipelineActiveMarker(activeOwner);
   const temporarySliceRefs: TemporarySliceRef[] = [];
   let finalAttempt = attempt;
+  let authoritySafeToRelease = slices.length === 0;
   let pipelinePrimaryError: unknown;
   try {
     const reviewConfig = resolveReviewConfig(spec);
@@ -1154,6 +1162,7 @@ export async function runPipeline(
           reason: args.reason,
           store,
         });
+      if (slices.length > 0) authoritySafeToRelease = true;
       finalAttempt = failedAttempt;
       return failedResult(
         failedAttempt,
@@ -1198,6 +1207,7 @@ export async function runPipeline(
           });
         } catch (error) {
           const archived = await archiveSliceExecutionError({ error, attempt, store });
+          authoritySafeToRelease = true;
           finalAttempt = archived.failedAttempt;
           if (error !== archived.sliceError) throw error;
           const failed = failedResult(
@@ -1366,6 +1376,7 @@ export async function runPipeline(
         });
       } catch (error) {
         const archived = await archiveSliceExecutionError({ error, attempt, store });
+        authoritySafeToRelease = true;
         finalAttempt = archived.failedAttempt;
         if (error !== archived.sliceError) throw error;
         const failed = failedResult(
@@ -1391,6 +1402,7 @@ export async function runPipeline(
           reason,
           store,
         });
+        authoritySafeToRelease = true;
         finalAttempt = failedAttempt;
         const failed = failedResult(
           failedAttempt,
@@ -1750,6 +1762,7 @@ export async function runPipeline(
       failure: null,
     };
     await store.writePipelineArtifact("pipeline-result", result);
+    authoritySafeToRelease = true;
     return result;
   } catch (error) {
     let terminalError = error;
@@ -1761,6 +1774,7 @@ export async function runPipeline(
           reason: "sliced pipeline terminated before completing trusted gates",
           store,
         });
+        authoritySafeToRelease = true;
       } catch (archiveError) {
         terminalError = new AggregateError(
           [error, archiveError],
@@ -1772,7 +1786,6 @@ export async function runPipeline(
     throw terminalError;
   } finally {
     const cleanupErrors = await cleanupTemporarySliceRefs(checkoutPath, temporarySliceRefs);
-    let canClearActiveMarker = true;
     if (cleanupErrors.length > 0
       && slices.length > 0
       && finalAttempt.status === "verified-candidate") {
@@ -1783,12 +1796,12 @@ export async function runPipeline(
           reason: "temporary slice ref cleanup did not complete",
           store,
         });
+        authoritySafeToRelease = true;
       } catch (archiveError) {
         cleanupErrors.push(archiveError);
-        canClearActiveMarker = false;
       }
     }
-    if (canClearActiveMarker) {
+    if (cleanupErrors.length === 0 && authoritySafeToRelease) {
       try {
         await store.clearPipelineActiveMarker();
       } catch (cleanupError) {

--- a/src/pipeline/pipeline-runtime.ts
+++ b/src/pipeline/pipeline-runtime.ts
@@ -1483,27 +1483,105 @@ async function runPipelineWithLease(
       if (phase.haltedSliceIndex !== null) {
         const halted = phase.slices.at(-1);
         const reason = `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`;
-        const failedAttempt = await archiveSlicedFailure({
+        if (currentCandidateCommit === baselineCommit) {
+          // No slice advanced past the baseline, so there is no partial branch
+          // for the human to accept. Retain the slice evidence and report the
+          // halt as a failure.
+          const failedAttempt = await archiveSlicedFailure({
+            checkoutPath,
+            attempt,
+            failure: "verification-failure",
+            reason,
+            store,
+          });
+          authoritySafeToRelease = true;
+          finalAttempt = failedAttempt;
+          const failed = failedResult(
+            failedAttempt,
+            rounds,
+            currentCandidateCommit,
+            reason,
+            "verification-failure",
+            increments,
+            phase.slices,
+            phase.haltedSliceIndex,
+          );
+          await store.writePipelineArtifact("pipeline-result", failed);
+          return failed;
+        }
+        // At least one slice advanced. Promote the partial branch (the advanced
+        // slices) to a frozen, acceptable candidate and hand the halt to the
+        // human — the design routes a mid-run halt to human-decision-required so
+        // the human can accept, reject, or revise the partial branch. The failed
+        // slice's attempts stay in `slices` as evidence. Review rounds are
+        // skipped; final verification runs so the human sees an honest report on
+        // the exact partial branch.
+        const promoted = await promoteFinalCandidate({
           checkoutPath,
           attempt,
-          failure: "verification-failure",
-          reason,
+          initialCandidate: attempt.candidate,
+          baselineCommit,
+          candidateCommit: currentCandidateCommit,
           store,
         });
+        if (promoted === null) {
+          const promotionReason = "partial halt candidate could not be promoted from the git object store";
+          const failedAttempt = await archiveSlicedFailure({
+            checkoutPath,
+            attempt,
+            failure: "sandbox-violation",
+            reason: promotionReason,
+            store,
+          });
+          authoritySafeToRelease = true;
+          finalAttempt = failedAttempt;
+          const failed = failedResult(
+            failedAttempt,
+            rounds,
+            currentCandidateCommit,
+            promotionReason,
+            "sandbox-violation",
+            increments,
+            phase.slices,
+            phase.haltedSliceIndex,
+          );
+          await store.writePipelineArtifact("pipeline-result", failed);
+          return failed;
+        }
+        finalAttempt = promoted.attempt;
+        currentCandidateCommit = promoted.candidateCommit;
         authoritySafeToRelease = true;
-        finalAttempt = failedAttempt;
-        const failed = failedResult(
-          failedAttempt,
-          rounds,
-          currentCandidateCommit,
-          reason,
-          "verification-failure",
+        notePhase("partial halt verification");
+        const verified = await verifyCandidate({
+          checkoutPath,
+          spec,
+          deps,
+          attempt: finalAttempt,
+          baselineCommit,
+          candidateCommit: currentCandidateCommit,
+          store,
+          namespace: "final",
+        });
+        await store.writePipelineArtifact("verification", verified.verification);
+        const haltResult: PipelineResult = {
+          runId: attempt.runId,
+          status: "human-decision-required",
+          attempt: finalAttempt,
           increments,
-          phase.slices,
-          phase.haltedSliceIndex,
-        );
-        await store.writePipelineArtifact("pipeline-result", failed);
-        return failed;
+          slices: phase.slices,
+          haltedSliceIndex: phase.haltedSliceIndex,
+          rounds,
+          verification: verified.verification,
+          gate: {
+            decisionReady: false,
+            requiresHumanDecision: true,
+            reasons: [reason],
+          },
+          finalCandidateCommit: currentCandidateCommit,
+          failure: null,
+        };
+        await store.writePipelineArtifact("pipeline-result", haltResult);
+        return haltResult;
       }
       frozenTestEvidence = sliceTestEvidence(phase.slices);
     }

--- a/src/pipeline/pipeline-runtime.ts
+++ b/src/pipeline/pipeline-runtime.ts
@@ -11,6 +11,7 @@ import type {
 import {
   resolveImplementationConfig,
   resolveReviewConfig,
+  resolveSlices,
   type DelegationSpec,
   type ReviewerKind,
   type Slice,
@@ -43,7 +44,10 @@ import type {
   VerificationReport,
 } from "./report-types.js";
 import type { PipelineRole, RolePackage } from "./role-prompts.js";
-import type { PipelineSlice } from "./slice-runner.js";
+import {
+  runSlicePhase,
+  type PipelineSlice,
+} from "./slice-runner.js";
 import {
   runRole as defaultRunRole,
   type RoleRunArgs,
@@ -348,6 +352,72 @@ function testEvidence(attempt: AttemptResult): string {
   })));
 }
 
+function attemptLogRefs(attempt: AttemptResult): string[] {
+  return [...new Set([
+    attempt.logsRef,
+    ...attempt.executedVerification.flatMap(outcome => [outcome.stdoutRef, outcome.stderrRef]),
+  ])];
+}
+
+function verificationTestEvidence(verification: VerificationReport): Record<string, unknown> {
+  return {
+    pass: verification.pass,
+    commandResults: verification.commandResults.map(command => ({ ...command })),
+    workspaceClean: verification.workspaceClean,
+    testsDeleted: verification.testsDeleted,
+    testsSkipped: verification.testsSkipped,
+    scopeViolations: [...verification.scopeViolations],
+  };
+}
+
+function sliceTestEvidence(slices: PipelineSlice[]): string {
+  return JSON.stringify(slices.map(slice => ({
+    sliceIndex: slice.index,
+    verification: slice.verification === null
+      ? null
+      : verificationTestEvidence(slice.verification),
+    attempts: slice.attempts.map(attempt => ({
+      attempt: attempt.attempt,
+      verification: attempt.verification === null
+        ? null
+        : verificationTestEvidence(attempt.verification),
+    })),
+  })));
+}
+
+class SliceExecutionError extends RuntimeError {
+  constructor(message: string, readonly failure: FailureClassification) {
+    super(message);
+    this.name = "SliceExecutionError";
+  }
+}
+
+async function withManagedWorktree<T>(args: {
+  manager: WorktreeManager;
+  commit: string;
+  cleanupFailureMessage: string;
+  run: (worktreePath: string) => Promise<T>;
+}): Promise<T> {
+  const worktree = await args.manager.create(args.commit);
+  let primaryError: unknown;
+  try {
+    return await args.run(worktree.path);
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    try {
+      await worktree.cleanup();
+    } catch (cleanupError) {
+      if (primaryError === undefined) throw cleanupError;
+      throw new AggregateError(
+        [primaryError, cleanupError],
+        args.cleanupFailureMessage,
+      );
+    }
+  }
+}
+
 function escapeRegex(character: string): string {
   return /[\\^$.*+?()[\]{}|]/.test(character) ? `\\${character}` : character;
 }
@@ -532,6 +602,66 @@ export async function runReviews(args: {
     throw new Error("unreachable invalid review state");
   }
   return { ok: false, failedRoleLogRef: failed.initialLogRef, roleLogRefs };
+}
+
+async function runSliceReview(args: {
+  checkoutPath: string;
+  spec: DelegationSpec;
+  deps: PipelineDependencies;
+  runId: string;
+  baselineCommit: string;
+  candidateCommit: string;
+  namespace: string;
+  reviewers: ReviewerKind[];
+  verification: PipelineVerificationReport;
+  store: ArtifactStore;
+}): Promise<{ review: ConsolidationResult; roleLogRefs: string[] }> {
+  const ps = args.deps.ps ?? getPlatformServices();
+  return withManagedWorktree({
+    manager: new WorktreeManager(
+      args.checkoutPath,
+      `${args.runId}-${args.namespace}-review`,
+      ps,
+    ),
+    commit: args.candidateCommit,
+    cleanupFailureMessage: "slice review failed and its worktree could not be cleaned up",
+    run: async worktreePath => {
+      const diffText = await checkedGit(worktreePath, [
+        "diff",
+        `${args.baselineCommit}..${args.candidateCommit}`,
+      ]);
+      const reviewRun = await runReviews({
+        reviewers: args.reviewers,
+        spec: args.spec,
+        pkg: {
+          spec: args.spec,
+          baselineCommit: args.baselineCommit,
+          candidateCommit: args.candidateCommit,
+          candidateDiff: diffText,
+          testEvidence: JSON.stringify(verificationTestEvidence(args.verification)),
+        },
+        worktreePath,
+        deps: args.deps,
+        runId: args.runId,
+        round: 1,
+        store: args.store,
+        logNameNamespace: args.namespace,
+      });
+      if (!reviewRun.ok) {
+        throw new SliceExecutionError(
+          `slice review did not produce valid structured output (see ${reviewRun.failedRoleLogRef})`,
+          "producer-failure",
+        );
+      }
+      return {
+        review: consolidate(reviewRun.reviews.map(review => ({
+          reviewer: review.reviewer,
+          report: review.report,
+        }))),
+        roleLogRefs: reviewRun.roleLogRefs,
+      };
+    },
+  });
 }
 
 async function runFix(args: {
@@ -839,13 +969,15 @@ export async function runPipeline(
   deps: PipelineDependencies,
 ): Promise<PipelineResult> {
   const runAttemptFn = deps.runAttempt ?? defaultRunAttempt;
+  const slices = resolveSlices(spec);
+  const initialSpec = slices.length === 0 ? spec : scopeSpecToSlice(spec, slices[0]!);
   const notePhase = (phase: string): void => {
     // Best-effort progress; must never affect pipeline control flow.
     try { deps.onPhase?.(phase); } catch { /* progress reporting is advisory */ }
   };
   let runStart: RunStartContext | undefined;
   const inheritedOnRunStart = deps.onRunStart;
-  const attempt = await runAttemptFn(checkoutPath, spec, {
+  const attempt = await runAttemptFn(checkoutPath, initialSpec, {
     ...deps,
     onRunStart(context) {
       runStart = context;
@@ -876,18 +1008,223 @@ export async function runPipeline(
   await store.writePipelineActiveMarker(activeOwner);
   let pipelinePrimaryError: unknown;
   try {
-    const { reviewers, maxRounds } = resolveReviewConfig(spec);
-    const { maxIncrements } = resolveImplementationConfig(spec);
+    const reviewConfig = resolveReviewConfig(spec);
+    const { reviewers, maxRounds } = reviewConfig;
+    const maxIncrements = slices.length === 0
+      ? resolveImplementationConfig(spec).maxIncrements
+      : 1;
     let finalAttempt = attempt;
     const increments: PipelineIncrement[] = [];
     let incrementOutcome: IncrementOutcome | undefined;
     const rounds: PipelineRound[] = [];
     const baselineCommit = attempt.candidate.baseCommitOid;
     let currentCandidateCommit = attempt.candidate.candidateCommitOid;
-    const frozenTestEvidence = testEvidence(attempt);
+    let frozenTestEvidence = testEvidence(attempt);
+    let pipelineSlices: PipelineSlice[] = [];
+
+    if (slices.length > 0) {
+      const initialNamespace = "slice-1-attempt-0";
+      const initialVerification = await verifyCandidate({
+        checkoutPath,
+        spec: initialSpec,
+        deps,
+        attempt,
+        baselineCommit,
+        candidateCommit: currentCandidateCommit,
+        store,
+        namespace: initialNamespace,
+      });
+      let initialPerSliceReview: ConsolidationResult | null = null;
+      const initialRoleLogRefs = attemptLogRefs(attempt);
+      if (reviewConfig.perSlice === true) {
+        const reviewed = await runSliceReview({
+          checkoutPath,
+          spec: initialSpec,
+          deps,
+          runId: attempt.runId,
+          baselineCommit,
+          candidateCommit: currentCandidateCommit,
+          namespace: initialNamespace,
+          reviewers,
+          verification: initialVerification.verification,
+          store,
+        });
+        initialPerSliceReview = reviewed.review;
+        initialRoleLogRefs.push(...reviewed.roleLogRefs);
+      }
+
+      const completedSlices: PipelineSlice[] = [];
+      let phase: Awaited<ReturnType<typeof runSlicePhase>>;
+      try {
+        phase = await runSlicePhase(slices, baselineCommit, {
+          maxRounds,
+          initialAttempt: {
+            candidateCommit: currentCandidateCommit,
+            verification: initialVerification.verification,
+            perSliceReview: initialPerSliceReview,
+            roleLogRefs: initialRoleLogRefs,
+          },
+          runSlice: async (slice, index, base, sliceAttempt) => {
+            const namespace = `slice-${index}-attempt-${sliceAttempt}`;
+            const scopedSpec = scopeSpecToSlice(spec, slice);
+            return withManagedWorktree({
+              manager: new WorktreeManager(
+                checkoutPath,
+                `${attempt.runId}-${namespace}`,
+                ps,
+              ),
+              commit: base,
+              cleanupFailureMessage:
+                "slice implementation failed and its worktree could not be cleaned up",
+              run: async worktreePath => {
+                let gitObjectAccess: LinkedWorktreeGitAccess;
+                try {
+                  gitObjectAccess = await resolveLinkedWorktreeWritableRoots(worktreePath);
+                } catch {
+                  throw new SliceExecutionError(
+                    "slice implementer git object isolation could not be established",
+                    "sandbox-violation",
+                  );
+                }
+                const incrementRun = await runIncrement({
+                  spec: scopedSpec,
+                  pkg: {
+                    spec: scopedSpec,
+                    baselineCommit: base,
+                    candidateCommit: base,
+                    candidateDiff: "",
+                    testEvidence: completedSlices.length === 0
+                      ? testEvidence(attempt)
+                      : sliceTestEvidence(completedSlices),
+                  },
+                  worktreePath,
+                  deps,
+                  runId: attempt.runId,
+                  increment: sliceAttempt + 1,
+                  store,
+                  gitObjectAccess,
+                  ...(runStart === undefined ? {} : { runStart }),
+                  logNameNamespace: namespace,
+                });
+                if (!incrementRun.ok) {
+                  throw new SliceExecutionError(
+                    `slice implementer did not produce valid structured output (see ${incrementRun.failedRoleLogRef})`,
+                    incrementRun.failure,
+                  );
+                }
+
+                const candidateCommit = incrementRun.report.candidateCommit;
+                const provenanceFailure = await validateCandidateProvenance({
+                  worktreePath,
+                  previousCandidateCommit: base,
+                  candidateCommit,
+                  gitObjectAccess,
+                });
+                if (provenanceFailure !== null) {
+                  throw new SliceExecutionError(
+                    provenanceFailure.reason,
+                    provenanceFailure.failure,
+                  );
+                }
+                if (candidateCommit !== base) {
+                  try {
+                    await importPromotedObjects({
+                      checkoutPath,
+                      baselineCommit: base,
+                      promotedCommit: candidateCommit,
+                      access: gitObjectAccess,
+                    });
+                  } catch {
+                    throw new SliceExecutionError(
+                      "slice candidate objects could not be imported into the shared git object store",
+                      "sandbox-violation",
+                    );
+                  }
+                }
+
+                const verified = await verifyCandidate({
+                  checkoutPath,
+                  spec: scopedSpec,
+                  deps,
+                  attempt,
+                  baselineCommit: base,
+                  candidateCommit,
+                  store,
+                  namespace,
+                });
+                let perSliceReview: ConsolidationResult | null = null;
+                const roleLogRefs = [...incrementRun.roleLogRefs];
+                if (reviewConfig.perSlice === true) {
+                  const reviewed = await runSliceReview({
+                    checkoutPath,
+                    spec: scopedSpec,
+                    deps,
+                    runId: attempt.runId,
+                    baselineCommit: base,
+                    candidateCommit,
+                    namespace,
+                    reviewers,
+                    verification: verified.verification,
+                    store,
+                  });
+                  perSliceReview = reviewed.review;
+                  roleLogRefs.push(...reviewed.roleLogRefs);
+                }
+                return {
+                  candidateCommit,
+                  verification: verified.verification,
+                  perSliceReview,
+                  roleLogRefs,
+                };
+              },
+            });
+          },
+          onAttempt: evidence => store.writePipelineArtifact(
+            `slice-${evidence.sliceIndex}-attempt-${evidence.attempt}`,
+            evidence,
+          ),
+          onSlice: async slice => {
+            await store.writePipelineArtifact(`slice-${slice.index}`, slice);
+            completedSlices.push(structuredClone(slice));
+          },
+        });
+      } catch (error) {
+        if (!(error instanceof SliceExecutionError)) throw error;
+        const failed = failedResult(
+          attempt,
+          rounds,
+          completedSlices.at(-1)?.candidateCommit ?? baselineCommit,
+          error.message,
+          error.failure,
+          increments,
+          completedSlices,
+        );
+        await store.writePipelineArtifact("pipeline-result", failed);
+        return failed;
+      }
+      pipelineSlices = phase.slices;
+      currentCandidateCommit = phase.finalCandidateCommit;
+      if (phase.haltedSliceIndex !== null) {
+        const halted = phase.slices.at(-1);
+        const failed = failedResult(
+          attempt,
+          rounds,
+          currentCandidateCommit,
+          `slice phase halted at slice ${phase.haltedSliceIndex}: ${halted?.reasons.join("; ") ?? "objective gate failed"}`,
+          "verification-failure",
+          increments,
+          phase.slices,
+          phase.haltedSliceIndex,
+        );
+        await store.writePipelineArtifact("pipeline-result", failed);
+        return failed;
+      }
+      frozenTestEvidence = sliceTestEvidence(phase.slices);
+    }
+
     const candidateWorktree = await new WorktreeManager(
       checkoutPath,
-      `${attempt.runId}-pipeline`,
+      slices.length === 0 ? `${attempt.runId}-pipeline` : `${attempt.runId}-composed-review`,
       ps,
     ).create(currentCandidateCommit);
     let gitObjectAccess: LinkedWorktreeGitAccess | null = null;
@@ -904,6 +1241,7 @@ export async function runPipeline(
             "increment git object isolation could not be established",
             "sandbox-violation",
             increments,
+            pipelineSlices,
           );
         }
 
@@ -941,6 +1279,7 @@ export async function runPipeline(
                 `increment phase did not produce valid structured output (see ${incrementRun.failedRoleLogRef})`,
                 incrementRun.failure,
                 increments,
+                pipelineSlices,
               );
             }
 
@@ -960,6 +1299,7 @@ export async function runPipeline(
                 provenanceFailure.reason,
                 provenanceFailure.failure,
                 increments,
+                pipelineSlices,
               );
             }
 
@@ -993,6 +1333,7 @@ export async function runPipeline(
                   "increment objects could not be imported into the shared git object store",
                   "sandbox-violation",
                   increments,
+                  pipelineSlices,
                 );
               }
             }
@@ -1025,6 +1366,7 @@ export async function runPipeline(
             "increment phase failed unexpectedly",
             "producer-failure",
             increments,
+            pipelineSlices,
           );
         }
       }
@@ -1060,6 +1402,7 @@ export async function runPipeline(
             `review phase did not produce valid structured output (see ${reviewRun.failedRoleLogRef})`,
             "producer-failure",
             increments,
+            pipelineSlices,
           );
         }
 
@@ -1093,6 +1436,7 @@ export async function runPipeline(
             "fixer git object isolation could not be established",
             "sandbox-violation",
             increments,
+            pipelineSlices,
           );
         }
 
@@ -1116,6 +1460,7 @@ export async function runPipeline(
             `fix phase did not produce valid structured output (see ${fixRun.failedRoleLogRef})`,
             fixRun.failure,
             increments,
+            pipelineSlices,
           );
         }
         const { fix } = fixRun;
@@ -1134,6 +1479,7 @@ export async function runPipeline(
             provenanceFailure.reason,
             provenanceFailure.failure,
             increments,
+            pipelineSlices,
           );
         }
         currentCandidateCommit = fix.candidateCommit;
@@ -1147,7 +1493,7 @@ export async function runPipeline(
       }
 
       if (currentCandidateCommit !== attempt.candidate.candidateCommitOid) {
-        if (gitObjectAccess === null) {
+        if (gitObjectAccess === null && slices.length === 0) {
           return failedResult(
             attempt,
             rounds,
@@ -1155,6 +1501,7 @@ export async function runPipeline(
             "fixer git object isolation state is missing during promotion",
             "sandbox-violation",
             increments,
+            pipelineSlices,
           );
         }
         const promoted = await promoteFinalCandidate({
@@ -1164,16 +1511,19 @@ export async function runPipeline(
           baselineCommit,
           candidateCommit: currentCandidateCommit,
           store,
-          privateObjectAccess: gitObjectAccess,
+          ...(gitObjectAccess === null ? {} : { privateObjectAccess: gitObjectAccess }),
         });
         if (promoted === null) {
           return failedResult(
             attempt,
             rounds,
             currentCandidateCommit,
-            "fixer objects could not be imported into the shared git object store",
+            slices.length === 0
+              ? "fixer objects could not be imported into the shared git object store"
+              : "sliced candidate could not be promoted from the shared git object store",
             "sandbox-violation",
             increments,
+            pipelineSlices,
           );
         }
         finalAttempt = promoted.attempt;
@@ -1203,6 +1553,7 @@ export async function runPipeline(
       baselineCommit,
       candidateCommit: currentCandidateCommit,
       store,
+      ...(slices.length === 0 ? {} : { namespace: "final" }),
     });
     await store.writePipelineArtifact("verification", verified.verification);
     const lastRound = rounds.at(-1);
@@ -1223,7 +1574,7 @@ export async function runPipeline(
       status: gate.decisionReady ? "decision-ready" : "human-decision-required",
       attempt: finalAttempt,
       increments,
-      slices: [],
+      slices: pipelineSlices,
       haltedSliceIndex: null,
       rounds,
       verification: verified.verification,

--- a/src/pipeline/pipeline-runtime.ts
+++ b/src/pipeline/pipeline-runtime.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { git, type GitExecOptions, type GitResult } from "../git/git-exec.js";
 import { WorktreeManager } from "../git/worktree-manager.js";
-import type { PlatformServices } from "../platform/platform-services.js";
+import type { CheckoutLock, PlatformServices } from "../platform/platform-services.js";
 import { getPlatformServices } from "../platform/select-platform.js";
 import type {
   CandidateArtifact,
@@ -22,7 +22,6 @@ import type { ProducerRegistry } from "../producers/producer-registry.js";
 import {
   runAttempt as defaultRunAttempt,
   type AttemptRuntimeDependencies,
-  type BorrowedCheckoutLease,
 } from "../runtime/attempt-runtime.js";
 import {
   ArtifactStore,
@@ -1128,10 +1127,6 @@ export async function runPipeline(
   const ps = deps.ps ?? getPlatformServices();
   const canonical = await ps.canonicalizePath(checkoutPath);
   const lock = await ps.acquireCheckoutLock(canonical.canonical);
-  const borrowedCheckoutLease: BorrowedCheckoutLease = {
-    lock,
-    repositoryIdentity: canonical.gitCommonDir ?? canonical.canonical,
-  };
   let primaryError: unknown;
   let hasPrimaryError = false;
   try {
@@ -1140,7 +1135,7 @@ export async function runPipeline(
       spec,
       deps,
       ps,
-      borrowedCheckoutLease,
+      lock,
     );
   } catch (error) {
     primaryError = error;
@@ -1164,7 +1159,7 @@ async function runPipelineWithLease(
   spec: DelegationSpec,
   deps: PipelineDependencies,
   ps: PlatformServices,
-  borrowedCheckoutLease: BorrowedCheckoutLease,
+  borrowedCheckoutLease: CheckoutLock,
 ): Promise<PipelineResult> {
   const runAttemptFn = deps.runAttempt ?? defaultRunAttempt;
   const slices = resolveSlices(spec);

--- a/src/pipeline/slice-runner.ts
+++ b/src/pipeline/slice-runner.ts
@@ -68,9 +68,10 @@ export async function runSlicePhase(
     const attempts: SliceAttemptEvidence[] = [];
 
     while (true) {
-      const attempt = index === 1 && roundsUsed === 0 && deps.initialAttempt !== undefined
+      const sourceAttempt = index === 1 && roundsUsed === 0 && deps.initialAttempt !== undefined
         ? deps.initialAttempt
         : await deps.runSlice(slice, index, currentCommit, roundsUsed);
+      const attempt = structuredClone(sourceAttempt);
       const perSliceReview = attempt.perSliceReview ?? null;
       const route = routeSlice({
         verification: attempt.verification,
@@ -91,11 +92,7 @@ export async function runSlicePhase(
       };
 
       if (deps.onAttempt) {
-        await deps.onAttempt({
-          ...evidence,
-          reasons: [...evidence.reasons],
-          roleLogRefs: [...evidence.roleLogRefs],
-        });
+        await deps.onAttempt(structuredClone(evidence));
       }
       attempts.push(evidence);
 
@@ -119,7 +116,7 @@ export async function runSlicePhase(
       if (route.route === 'advance') {
         results.push(pipelineSlice);
         if (deps.onSlice) {
-          await deps.onSlice(pipelineSlice);
+          await deps.onSlice(structuredClone(pipelineSlice));
         }
         currentCommit = attempt.candidateCommit;
         break;
@@ -132,7 +129,7 @@ export async function runSlicePhase(
 
       results.push(pipelineSlice);
       if (deps.onSlice) {
-        await deps.onSlice(pipelineSlice);
+        await deps.onSlice(structuredClone(pipelineSlice));
       }
       return {
         slices: results,

--- a/src/pipeline/slice-runner.ts
+++ b/src/pipeline/slice-runner.ts
@@ -1,6 +1,18 @@
 import type { Slice } from '../protocol/delegation-spec.js';
+import type { ConsolidationResult } from './consolidator.js';
 import type { VerificationReport } from './report-types.js';
 import { routeSlice, type SliceRoute } from './wayfinder.js';
+
+export interface SliceAttemptEvidence {
+  sliceIndex: number;
+  attempt: number;
+  candidateCommit: string;
+  verification: VerificationReport | null;
+  perSliceReview: ConsolidationResult | null;
+  route: SliceRoute;
+  reasons: string[];
+  roleLogRefs: string[];
+}
 
 export interface PipelineSlice {
   index: number;
@@ -9,12 +21,17 @@ export interface PipelineSlice {
   candidateCommit: string;
   roundsUsed: number;
   verification: VerificationReport | null;
+  perSliceReview: ConsolidationResult | null;
   reasons: string[];
+  attempts: SliceAttemptEvidence[];
+  roleLogRefs: string[];
 }
 
 export interface SliceAttempt {
   candidateCommit: string;
   verification: VerificationReport | null;
+  perSliceReview?: ConsolidationResult | null;
+  roleLogRefs?: string[];
   hardBlocker?: boolean;
 }
 
@@ -26,6 +43,8 @@ export interface SlicePhaseDeps {
     attempt: number,
   ) => Promise<SliceAttempt>;
   maxRounds: number;
+  initialAttempt?: SliceAttempt;
+  onAttempt?: (evidence: SliceAttemptEvidence) => Promise<void>;
   onSlice?: (result: PipelineSlice) => Promise<void>;
 }
 
@@ -46,16 +65,40 @@ export async function runSlicePhase(
   for (const [offset, slice] of slices.entries()) {
     const index = offset + 1;
     let roundsUsed = 0;
+    const attempts: SliceAttemptEvidence[] = [];
 
     while (true) {
-      const attempt = await deps.runSlice(slice, index, currentCommit, roundsUsed);
+      const attempt = index === 1 && roundsUsed === 0 && deps.initialAttempt !== undefined
+        ? deps.initialAttempt
+        : await deps.runSlice(slice, index, currentCommit, roundsUsed);
+      const perSliceReview = attempt.perSliceReview ?? null;
       const route = routeSlice({
         verification: attempt.verification,
-        perSliceReview: null,
+        perSliceReview,
         roundsUsed,
         maxRounds: deps.maxRounds,
         hardBlocker: attempt.hardBlocker ?? false,
       });
+      const evidence: SliceAttemptEvidence = {
+        sliceIndex: index,
+        attempt: roundsUsed,
+        candidateCommit: attempt.candidateCommit,
+        verification: attempt.verification,
+        perSliceReview,
+        route: route.route,
+        reasons: [...route.reasons],
+        roleLogRefs: [...(attempt.roleLogRefs ?? [])],
+      };
+
+      if (deps.onAttempt) {
+        await deps.onAttempt({
+          ...evidence,
+          reasons: [...evidence.reasons],
+          roleLogRefs: [...evidence.roleLogRefs],
+        });
+      }
+      attempts.push(evidence);
+
       const pipelineSlice: PipelineSlice = {
         index,
         objective: slice.objective,
@@ -63,7 +106,14 @@ export async function runSlicePhase(
         candidateCommit: attempt.candidateCommit,
         roundsUsed,
         verification: attempt.verification,
-        reasons: route.reasons,
+        perSliceReview,
+        reasons: [...route.reasons],
+        attempts: attempts.map(entry => ({
+          ...entry,
+          reasons: [...entry.reasons],
+          roleLogRefs: [...entry.roleLogRefs],
+        })),
+        roleLogRefs: attempts.flatMap(entry => entry.roleLogRefs),
       };
 
       if (route.route === 'advance') {

--- a/src/platform/platform-services.ts
+++ b/src/platform/platform-services.ts
@@ -34,7 +34,11 @@ export interface SupervisedExit {
   truncated: { stdout: boolean; stderr: boolean };
   spawnError?: unknown;             // set when the child emitted 'error' before start (→ spawn-failure)
 }
-export interface CheckoutLock { key: string; release(): Promise<void>; }
+export interface CheckoutLock {
+  key: string;
+  readonly repositoryIdentity: string;
+  release(): Promise<void>;
+}
 export interface CanonicalPath { input: string; canonical: string; gitCommonDir: string | null; }
 
 export interface PlatformServices {

--- a/src/platform/posix-platform-services.ts
+++ b/src/platform/posix-platform-services.ts
@@ -29,7 +29,7 @@ export async function acquireWxFileLock(
   key: string,
   timeoutMessage?: string,
   ownerToken: string | null = null,
-): Promise<CheckoutLock> {
+): Promise<Omit<CheckoutLock, "repositoryIdentity">> {
   const lockDirectory = path.join(resolveStateDir(), "locks");
   const lockPath = path.join(lockDirectory, `${key}.lock`);
   await fs.mkdir(lockDirectory, { recursive: true });
@@ -181,9 +181,11 @@ export class PosixPlatformServices implements PlatformServices {
 
   async acquireCheckoutLock(checkout: string): Promise<CheckoutLock> {
     const { canonical, gitCommonDir: commonDir } = await this.canonicalizePath(checkout);
-    const key = createHash("sha256").update(commonDir ?? canonical).digest("hex");
+    const repositoryIdentity = commonDir ?? canonical;
+    const key = createHash("sha256").update(repositoryIdentity).digest("hex");
     const ownerToken = await this.getProcessStartToken(nodeProcess.pid);
-    return acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
+    const lock = await acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
+    return { ...lock, repositoryIdentity };
   }
 
   async createSecureTempDirectory(): Promise<string> {

--- a/src/platform/windows-platform-services.ts
+++ b/src/platform/windows-platform-services.ts
@@ -305,9 +305,11 @@ export class WindowsPlatformServices implements PlatformServices {
   }
   async acquireCheckoutLock(checkout: string): Promise<CheckoutLock> {
     const { canonical, gitCommonDir: commonDir } = await this.canonicalizePath(checkout);
-    const key = createHash("sha256").update(commonDir ?? canonical).digest("hex");
+    const repositoryIdentity = commonDir ?? canonical;
+    const key = createHash("sha256").update(repositoryIdentity).digest("hex");
     const ownerToken = await this.getProcessStartToken(nodeProcess.pid);
-    return acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
+    const lock = await acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
+    return { ...lock, repositoryIdentity };
   }
 
   async createSecureTempDirectory(): Promise<string> {

--- a/src/protocol/versions.ts
+++ b/src/protocol/versions.ts
@@ -1,4 +1,4 @@
 export const PROTOCOL_VERSION = "1.3.0" as const;      // MCP tool contract version
 export const DELEGATION_SPEC_VERSION = "1" as const;   // wire schema major
 export const ATTEMPT_RESULT_VERSION = "1" as const;
-export const RUNTIME_VERSION = "0.20.0" as const;       // mirrors plugin.json at release
+export const RUNTIME_VERSION = "0.21.0" as const;       // mirrors plugin.json at release

--- a/src/protocol/versions.ts
+++ b/src/protocol/versions.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = "1.2.0" as const;      // MCP tool contract version
+export const PROTOCOL_VERSION = "1.3.0" as const;      // MCP tool contract version
 export const DELEGATION_SPEC_VERSION = "1" as const;   // wire schema major
 export const ATTEMPT_RESULT_VERSION = "1" as const;
 export const RUNTIME_VERSION = "0.20.0" as const;       // mirrors plugin.json at release

--- a/src/runtime/artifact-store.ts
+++ b/src/runtime/artifact-store.ts
@@ -34,6 +34,8 @@ import {
   type RunManifest,
 } from "./run-manifest.js";
 import { resolveStateDir } from "./state-dir.js";
+import { getPlatformServices } from "../platform/select-platform.js";
+import type { CheckoutLock, PlatformServices } from "../platform/platform-services.js";
 
 const SAFE_COMPONENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const WINDOWS_RESERVED_COMPONENT = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
@@ -52,6 +54,10 @@ export interface PrunePolicy {
 export interface PruneResult {
   removed: string[];
   retained: Array<{ runId: string; reason: string }>;
+}
+
+export interface PruneDependencies {
+  platformServices?: Pick<PlatformServices, "acquireCheckoutLock" | "canonicalizePath">;
 }
 
 export type RunDecisionValue = "accepted" | "rejected" | "revision-requested";
@@ -924,11 +930,13 @@ export class ArtifactStore {
   private async prepareCandidateAnchorCleanup(
     runId: string,
     result: AttemptResult,
+    manifest: RunManifest,
+    canonicalRepoRoot: string,
   ): Promise<PreparedAnchorCleanup> {
     if (result.candidate === null) {
       return {
         outcome: "not-applicable",
-        repoRoot: null,
+        repoRoot: canonicalRepoRoot,
         anchorRef: null,
         backupRef: null,
         candidateCommitOid: null,
@@ -943,15 +951,10 @@ export class ArtifactStore {
     if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(candidate.candidateCommitOid)) {
       throw new RuntimeError("archived candidate commit oid is invalid");
     }
-    const manifest = await this.readManifest(runId);
-    if (manifest === null) {
-      throw new RuntimeError("cannot remove candidate anchor without archived repository root");
-    }
     if (manifest.baseCommitOid !== candidate.baseCommitOid
       || manifest.candidateManifestHash !== candidate.manifestHash) {
       throw new RuntimeError("archived candidate does not match its run manifest");
     }
-    const canonicalRepoRoot = await realpath(manifest.repoRoot);
     const repositoryTopLevel = await git(canonicalRepoRoot, ["rev-parse", "--show-toplevel"]);
     if (repositoryTopLevel.exitCode !== 0
       || await realpath(repositoryTopLevel.stdout.trim()) !== canonicalRepoRoot) {
@@ -1103,7 +1106,10 @@ export class ArtifactStore {
     });
   }
 
-  async prune(policy: PrunePolicy): Promise<PruneResult> {
+  async prune(
+    policy: PrunePolicy,
+    dependencies: PruneDependencies = {},
+  ): Promise<PruneResult> {
     validatePruneLimit(policy.maxAgeMs, "maxAgeMs");
     validatePruneLimit(policy.maxBytes, "maxBytes");
 
@@ -1122,13 +1128,62 @@ export class ArtifactStore {
       let transaction: AnchorCleanupTransaction | null = null;
       let runsRootIdentity: DirectoryIdentity | null = null;
       let archiveRemovalCommitted = false;
+      let lease: CheckoutLock | null = null;
       try {
+        // Fast path: never wait on a checkout lease for a run that still
+        // advertises a live pipeline. Refuse before canonicalizing or locking.
+        if (await this.readPipelineActiveMarker(entry.runId) !== null) {
+          retained.push({ runId: entry.runId, reason: "active-run" });
+          return;
+        }
+        const initialManifest = await this.readManifest(entry.runId);
+        if (initialManifest === null) {
+          retained.push({ runId: entry.runId, reason: "incomplete-run" });
+          return;
+        }
+        const initialResult = await this.readResult(entry.runId);
+        if (initialResult === null) {
+          retained.push({ runId: entry.runId, reason: "incomplete-run" });
+          return;
+        }
+        // Serialize archive removal against the checkout lifecycle: hold the
+        // repository's checkout lease so recovery/integration cannot race a
+        // prune that is deleting the same candidate anchors.
+        const platformServices = dependencies.platformServices ?? getPlatformServices();
+        const canonical = await platformServices.canonicalizePath(initialManifest.repoRoot);
+        const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
+        lease = await platformServices.acquireCheckoutLock(canonical.canonical);
+        if (lease.repositoryIdentity !== repositoryIdentity) {
+          throw new RuntimeError("checkout lease repository identity changed before pruning");
+        }
+        await assertDirectoryIdentity(entry.directory, entry.identity);
+        // Re-establish authority under the lease: the manifest, terminal
+        // result, and active marker may all have changed while we waited.
+        const currentManifest = await this.readManifest(entry.runId);
+        if (currentManifest === null
+          || serializeJson(currentManifest) !== serializeJson(initialManifest)) {
+          retained.push({ runId: entry.runId, reason: "run identity changed while waiting" });
+          return;
+        }
+        if (await this.readPipelineActiveMarker(entry.runId) !== null) {
+          retained.push({ runId: entry.runId, reason: "active-run" });
+          return;
+        }
         const result = await this.readResult(entry.runId);
         if (result === null) {
           retained.push({ runId: entry.runId, reason: "incomplete-run" });
           return;
         }
-        prepared = await this.prepareCandidateAnchorCleanup(entry.runId, result);
+        if (serializeJson(result) !== serializeJson(initialResult)) {
+          retained.push({ runId: entry.runId, reason: "terminal authority changed while waiting" });
+          return;
+        }
+        prepared = await this.prepareCandidateAnchorCleanup(
+          entry.runId,
+          result,
+          currentManifest,
+          canonical.canonical,
+        );
         await this.appendCleanupRecord({
           event: "prune-cleanup-intent",
           runId: entry.runId,
@@ -1223,6 +1278,22 @@ export class ArtifactStore {
             runId: entry.runId,
             reason: redact(`${primary}${rollback}`),
           });
+        }
+      } finally {
+        if (lease !== null) {
+          try {
+            await lease.release();
+          } catch (error) {
+            // A release failure must never be swallowed. Surface it, and make
+            // clear whether the archive was already removed under the lease.
+            const reason = redact(error instanceof Error ? error.message : String(error));
+            retained.push({
+              runId: entry.runId,
+              reason: archiveRemovalCommitted
+                ? `archive removed; checkout lease release failed: ${reason}`
+                : reason,
+            });
+          }
         }
       }
     };

--- a/src/runtime/artifact-store.ts
+++ b/src/runtime/artifact-store.ts
@@ -65,6 +65,7 @@ export interface PipelineActiveMarker {
   pid: number;
   processToken: string | null;
   startedAt: string;
+  sliced: boolean;
 }
 
 interface RunEntry {
@@ -846,7 +847,8 @@ export class ArtifactStore {
       || marker.pid <= 1
       || (marker.processToken !== null && typeof marker.processToken !== "string")
       || typeof marker.startedAt !== "string"
-      || !Number.isFinite(Date.parse(marker.startedAt))) {
+      || !Number.isFinite(Date.parse(marker.startedAt))
+      || typeof marker.sliced !== "boolean") {
       throw new RuntimeError("pipeline-active marker is invalid");
     }
     await this.replaceJson("pipeline-active.json", marker);
@@ -869,10 +871,14 @@ export class ArtifactStore {
         || value.pid <= 1
         || (value.processToken !== null && typeof value.processToken !== "string")
         || typeof value.startedAt !== "string"
-        || !Number.isFinite(Date.parse(value.startedAt))) {
+        || !Number.isFinite(Date.parse(value.startedAt))
+        || (value.sliced !== undefined && typeof value.sliced !== "boolean")) {
         throw new RuntimeError("archived pipeline-active marker is malformed");
       }
-      return value as PipelineActiveMarker;
+      return {
+        ...value,
+        sliced: value.sliced ?? false,
+      } as PipelineActiveMarker;
     } catch (error) {
       if (isMissing(error)) return null;
       throw error;

--- a/src/runtime/attempt-runtime.ts
+++ b/src/runtime/attempt-runtime.ts
@@ -109,11 +109,6 @@ export interface AcceptanceVerifierLike {
   verify(args: AcceptanceVerificationArgs): Promise<AcceptanceVerificationResult>;
 }
 
-export interface BorrowedCheckoutLease {
-  readonly lock: CheckoutLock;
-  readonly repositoryIdentity: string;
-}
-
 export interface AttemptRuntimeDependencies {
   verifier: AcceptanceVerifierLike;
   baselineVerifier?: typeof verifyBaseline;
@@ -130,7 +125,7 @@ export interface AttemptRuntimeDependencies {
     baseCommitOid: string,
   ) => Promise<ReproducibilityInputs>;
   /** Trusted runtime handoff; never derived from the delegation specification. */
-  borrowedCheckoutLease?: BorrowedCheckoutLease;
+  borrowedCheckoutLease?: CheckoutLock;
   onRunStart?: (context: RunStartContext) => void | Promise<void>;
   /** Host progress reporting only; never awaited and never affects the attempt. */
   onPhase?: (phase: string) => void;
@@ -349,11 +344,7 @@ export async function runAttempt(
   const store = new ArtifactStore(runId);
   const canonical = await ps.canonicalizePath(checkoutPath);
   const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
-  if (deps.borrowedCheckoutLease !== undefined
-    && deps.borrowedCheckoutLease.repositoryIdentity !== repositoryIdentity) {
-    throw new RuntimeError("borrowed checkout lease repository identity mismatch");
-  }
-  let lock: CheckoutLock | null = deps.borrowedCheckoutLease?.lock ?? null;
+  let lock: CheckoutLock | null = deps.borrowedCheckoutLease ?? null;
   let ownedLock: CheckoutLock | null = null;
   let worktree: { path: string; cleanup(): Promise<void> } | null = null;
   let tempHome: string | null = null;
@@ -363,6 +354,9 @@ export async function runAttempt(
     if (lock === null) {
       ownedLock = await ps.acquireCheckoutLock(canonical.canonical);
       lock = ownedLock;
+    }
+    if (lock.repositoryIdentity !== repositoryIdentity) {
+      throw new RuntimeError("borrowed checkout lease repository identity mismatch");
     }
     const preconditions = await checkPreconditions(canonical.canonical, {
       writeAllowlist: spec.writeAllowlist,

--- a/src/runtime/attempt-runtime.ts
+++ b/src/runtime/attempt-runtime.ts
@@ -109,6 +109,11 @@ export interface AcceptanceVerifierLike {
   verify(args: AcceptanceVerificationArgs): Promise<AcceptanceVerificationResult>;
 }
 
+export interface BorrowedCheckoutLease {
+  readonly lock: CheckoutLock;
+  readonly repositoryIdentity: string;
+}
+
 export interface AttemptRuntimeDependencies {
   verifier: AcceptanceVerifierLike;
   baselineVerifier?: typeof verifyBaseline;
@@ -124,6 +129,8 @@ export interface AttemptRuntimeDependencies {
     repoRoot: string,
     baseCommitOid: string,
   ) => Promise<ReproducibilityInputs>;
+  /** Trusted runtime handoff; never derived from the delegation specification. */
+  borrowedCheckoutLease?: BorrowedCheckoutLease;
   onRunStart?: (context: RunStartContext) => void | Promise<void>;
   /** Host progress reporting only; never awaited and never affects the attempt. */
   onPhase?: (phase: string) => void;
@@ -341,13 +348,22 @@ export async function runAttempt(
   const runId = (deps.runId ?? randomUUID)();
   const store = new ArtifactStore(runId);
   const canonical = await ps.canonicalizePath(checkoutPath);
-  let lock: CheckoutLock | null = null;
+  const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
+  if (deps.borrowedCheckoutLease !== undefined
+    && deps.borrowedCheckoutLease.repositoryIdentity !== repositoryIdentity) {
+    throw new RuntimeError("borrowed checkout lease repository identity mismatch");
+  }
+  let lock: CheckoutLock | null = deps.borrowedCheckoutLease?.lock ?? null;
+  let ownedLock: CheckoutLock | null = null;
   let worktree: { path: string; cleanup(): Promise<void> } | null = null;
   let tempHome: string | null = null;
   let builtEnvironment: BuiltEnvironment | null = null;
   let primaryError: unknown;
   try {
-    lock = await ps.acquireCheckoutLock(canonical.canonical);
+    if (lock === null) {
+      ownedLock = await ps.acquireCheckoutLock(canonical.canonical);
+      lock = ownedLock;
+    }
     const preconditions = await checkPreconditions(canonical.canonical, {
       writeAllowlist: spec.writeAllowlist,
     });
@@ -680,7 +696,7 @@ export async function runAttempt(
       builtEnvironment,
       worktree,
       tempHome,
-      lock,
+      lock: ownedLock,
     });
     if (primaryError === undefined && cleanupError !== null) throw cleanupError;
   }

--- a/src/runtime/attempt-runtime.ts
+++ b/src/runtime/attempt-runtime.ts
@@ -356,7 +356,8 @@ export async function runAttempt(
       lock = ownedLock;
     }
     if (lock.repositoryIdentity !== repositoryIdentity) {
-      throw new RuntimeError("borrowed checkout lease repository identity mismatch");
+      const ownership = ownedLock === null ? "borrowed" : "owned";
+      throw new RuntimeError(`${ownership} checkout lease repository identity mismatch`);
     }
     const preconditions = await checkPreconditions(canonical.canonical, {
       writeAllowlist: spec.writeAllowlist,

--- a/src/runtime/attempt-runtime.ts
+++ b/src/runtime/attempt-runtime.ts
@@ -124,7 +124,7 @@ export interface AttemptRuntimeDependencies {
     repoRoot: string,
     baseCommitOid: string,
   ) => Promise<ReproducibilityInputs>;
-  onRunStart?: (context: RunStartContext) => void;
+  onRunStart?: (context: RunStartContext) => void | Promise<void>;
   /** Host progress reporting only; never awaited and never affects the attempt. */
   onPhase?: (phase: string) => void;
 }
@@ -494,7 +494,7 @@ export async function runAttempt(
       startedAt: new Date(startedAtMs).toISOString(),
     };
     const runStartContext = await initializeRunStart(store, runStart);
-    deps.onRunStart?.(runStartContext);
+    await deps.onRunStart?.(runStartContext);
     worktree = await new WorktreeManager(canonical.canonical, runId, ps).create(
       preconditions.baseCommitOid,
     );

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -419,7 +419,9 @@ async function temporarySliceRefs(
     if (fields[1] === undefined || !OID.test(fields[1])) {
       throw new RuntimeError("temporary slice ref OID is malformed during recovery");
     }
-    const object = await runGit(repoRoot, ["cat-file", "-t", fields[1]]);
+    const object = await runGit(repoRoot, ["cat-file", "-t", fields[1]], {
+      env: { GIT_NO_REPLACE_OBJECTS: "1" },
+    });
     if (object.exitCode !== 0 || object.stdout.trim() !== "commit") {
       throw new RuntimeError("temporary slice ref does not identify a commit during recovery");
     }
@@ -812,7 +814,7 @@ export async function recoverStaleRuns(
           pid => ps.getProcessStartToken(pid),
         )) {
           const commonDir = await validateGitCommonDir(record.canonicalCommonDir);
-          await archiveInterruptedPipeline(store, result);
+          if (marker.sliced) await archiveInterruptedPipeline(store, result);
           await cleanupManagedWorktrees(commonDir, root, entry.name, ps);
           await cleanupTemporarySliceRefs(commonDir, entry.name, runGit);
           await store.clearPipelineActiveMarker();

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -1204,6 +1204,17 @@ async function truncateCleanupTornTail(filename: string): Promise<void> {
     }
     const text = await handle.readFile({ encoding: "utf8" });
     if (text === "" || text.endsWith("\n")) return;
+    // A concurrent live prune may append+fsync a fresh intent between the reader's
+    // scan and this truncate. Re-validate that we read exactly the stat'd bytes and
+    // that the journal has not grown or changed since, and fail closed rather than
+    // truncate away a durably-journaled intent (matches the reader's stability gate).
+    const settled = await handle.stat();
+    if (Buffer.byteLength(text, "utf8") !== metadata.size
+      || settled.size !== metadata.size
+      || settled.mtimeMs !== metadata.mtimeMs
+      || settled.ctimeMs !== metadata.ctimeMs) {
+      throw new RuntimeError("cleanup journal changed during torn-tail repair");
+    }
     const finalNewline = text.lastIndexOf("\n");
     const completePrefix = finalNewline === -1 ? "" : text.slice(0, finalNewline + 1);
     await handle.truncate(Buffer.byteLength(completePrefix, "utf8"));
@@ -1983,7 +1994,6 @@ export async function recoverStaleRuns(
     // The reconciler completes interrupted prunes under a per-repo checkout lease
     // rather than deferring them, so no run is skipped for a pending prune.
     if (runsIdentity !== null) await replayInterruptedPrunes(runsRoot, ps);
-    const deferredPruneRunIds = new Set<string>();
     const journaledQuarantines = runsIdentity === null
       ? new Set<string>()
       : (await readRecoveryQuarantineJournal(runsRoot)).runIds;
@@ -2002,7 +2012,6 @@ export async function recoverStaleRuns(
           }
           continue;
         }
-        if (deferredPruneRunIds.has(entry.name)) continue;
         if (!entry.isDirectory() || entry.isSymbolicLink() || !SAFE_RUN_ID.test(entry.name)) continue;
         try {
           const runDirectory = path.join(runsRoot, entry.name);

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -13,6 +13,7 @@ import { git, type GitResult } from "../git/git-exec.js";
 import { WorktreeManager } from "../git/worktree-manager.js";
 import type { PlatformServices } from "../platform/platform-services.js";
 import { getPlatformServices } from "../platform/select-platform.js";
+import type { AttemptResult } from "../protocol/attempt-result.js";
 import { RuntimeError } from "../util/errors.js";
 import { ArtifactStore } from "./artifact-store.js";
 import { resolveStateDir } from "./state-dir.js";
@@ -24,6 +25,7 @@ const LOCK_NAME = /^([0-9a-f]{64})\.lock$/;
 const OID = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 const CANDIDATE_REF_PREFIX = "refs/claude-architect/candidates/";
 const BACKUP_REF_PREFIX = "refs/claude-architect/prune-backups/";
+const SLICE_REF_PREFIX = "refs/claude-architect/slices/";
 
 interface RunStartRecord {
   runId: string;
@@ -62,6 +64,7 @@ export interface RecoveryDependencies {
   requestCooperativeTermination?: (pid: number) => void | Promise<void>;
   delayMs?: (ms: number) => Promise<void>;
   graceMs?: number;
+  git?: typeof git;
 }
 
 interface LockOwner {
@@ -265,13 +268,17 @@ async function validateRepositoryRoot(repoRoot: string): Promise<string> {
   return canonical;
 }
 
-async function readDirectRef(repoRoot: string, ref: string): Promise<string | null> {
-  const symbolic = await git(repoRoot, ["symbolic-ref", "--quiet", ref]);
+async function readDirectRef(
+  repoRoot: string,
+  ref: string,
+  runGit: typeof git = git,
+): Promise<string | null> {
+  const symbolic = await runGit(repoRoot, ["symbolic-ref", "--quiet", ref]);
   if (symbolic.exitCode === 0) {
     throw new RuntimeError("recovery refuses to mutate a symbolic Git ref");
   }
   if (symbolic.exitCode !== 1) throw runGitError("inspect symbolic Git ref", symbolic);
-  const direct = await git(repoRoot, ["rev-parse", "--verify", "--quiet", ref]);
+  const direct = await runGit(repoRoot, ["rev-parse", "--verify", "--quiet", ref]);
   if (direct.exitCode === 1) return null;
   if (direct.exitCode !== 0 || !OID.test(direct.stdout.trim())) {
     throw runGitError("inspect Git ref", direct);
@@ -279,8 +286,13 @@ async function readDirectRef(repoRoot: string, ref: string): Promise<string | nu
   return direct.stdout.trim();
 }
 
-async function deleteExactRef(repoRoot: string, ref: string, oid: string): Promise<void> {
-  const result = await git(repoRoot, ["update-ref", "--no-deref", "-d", ref, oid]);
+async function deleteExactRef(
+  repoRoot: string,
+  ref: string,
+  oid: string,
+  runGit: typeof git = git,
+): Promise<void> {
+  const result = await runGit(repoRoot, ["update-ref", "--no-deref", "-d", ref, oid]);
   if (result.exitCode !== 0) throw runGitError("delete recovery Git ref", result);
 }
 
@@ -299,6 +311,138 @@ async function removeStaleCandidateAnchor(repoRoot: string, runId: string): Prom
   const ref = `${CANDIDATE_REF_PREFIX}${runId}`;
   const oid = await readDirectRef(repoRoot, ref);
   if (oid !== null) await deleteExactRef(repoRoot, ref, oid);
+}
+
+async function archiveInterruptedPipeline(
+  store: ArtifactStore,
+  result: AttemptResult,
+): Promise<void> {
+  if (result.status !== "verified-candidate") return;
+  const manifest = await store.readManifest(result.runId);
+  if (manifest === null) {
+    throw new RuntimeError("run manifest is missing while recovering interrupted pipeline");
+  }
+  const failed: AttemptResult = {
+    ...result,
+    status: "failed",
+    failure: "verification-failure",
+    summary: "Delegation pipeline was interrupted before trusted gates completed.",
+    unresolvedIssues: [
+      ...result.unresolvedIssues,
+      "pipeline-interrupted-before-terminal-cleanup",
+    ],
+    evidence: {
+      ...result.evidence,
+      pipelineRecovery: "interrupted-before-terminal-cleanup",
+    },
+  };
+  await store.promoteTerminalArtifacts({ result: failed, manifest });
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isManagedWorktreeId(runId: string, managedId: string): boolean {
+  if (new Set([
+    runId,
+    `baseline-${runId}`,
+    `verify-${runId}`,
+    `${runId}-pipeline`,
+    `${runId}-verify`,
+    `verify-${runId}-pipeline`,
+    `${runId}-composed-review`,
+    `${runId}-final-verify`,
+    `verify-${runId}-final-pipeline`,
+  ]).has(managedId)) return true;
+  const escapedRunId = escapeRegex(runId);
+  const index = "[1-9][0-9]*";
+  const attempt = "(?:0|[1-9][0-9]*)";
+  return new RegExp(
+    `^${escapedRunId}-slice-${index}-attempt-${attempt}(?:-review|-verify)?$`,
+  ).test(managedId)
+    || new RegExp(
+      `^verify-${escapedRunId}-slice-${index}-attempt-${attempt}-pipeline$`,
+    ).test(managedId);
+}
+
+async function managedWorktreeIds(root: string, runId: string): Promise<string[]> {
+  const worktreesRoot = path.join(root, "worktrees");
+  if (await plainDirectoryIdentity(worktreesRoot) === null) return [];
+  const entries = await readdir(worktreesRoot, { withFileTypes: true });
+  return entries
+    .map(entry => entry.name)
+    .filter(managedId => isManagedWorktreeId(runId, managedId))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+async function cleanupManagedWorktrees(
+  commonDir: string,
+  root: string,
+  runId: string,
+  ps: Pick<PlatformServices, "os">,
+): Promise<void> {
+  for (const managedId of await managedWorktreeIds(root, runId)) {
+    const worktreePath = path.join(root, "worktrees", managedId);
+    if (await plainDirectoryIdentity(worktreePath) !== null) {
+      await new WorktreeManager(commonDir, managedId, ps).remove(worktreePath);
+    }
+  }
+}
+
+interface TemporarySliceRef {
+  ref: string;
+  oid: string;
+}
+
+async function temporarySliceRefs(
+  repoRoot: string,
+  runId: string,
+  runGit: typeof git,
+): Promise<TemporarySliceRef[]> {
+  const prefix = `${SLICE_REF_PREFIX}${runId}/`;
+  const listed = await runGit(repoRoot, [
+    "for-each-ref",
+    "--format=%(refname)%09%(objectname)",
+    prefix,
+  ]);
+  if (listed.exitCode !== 0) throw runGitError("enumerate temporary slice refs", listed);
+  const expectedName = new RegExp(
+    `^${escapeRegex(prefix)}slice-[1-9][0-9]*-attempt-(?:0|[1-9][0-9]*)$`,
+  );
+  const refs: TemporarySliceRef[] = [];
+  for (const line of listed.stdout.split("\n").filter(Boolean)) {
+    const fields = line.split("\t");
+    if (fields.length !== 2 || fields[0] === undefined || !expectedName.test(fields[0])) {
+      throw new RuntimeError("temporary slice ref name is malformed during recovery");
+    }
+    if (fields[1] === undefined || !OID.test(fields[1])) {
+      throw new RuntimeError("temporary slice ref OID is malformed during recovery");
+    }
+    const object = await runGit(repoRoot, ["cat-file", "-t", fields[1]]);
+    if (object.exitCode !== 0 || object.stdout.trim() !== "commit") {
+      throw new RuntimeError("temporary slice ref does not identify a commit during recovery");
+    }
+    refs.push({ ref: fields[0], oid: fields[1] });
+  }
+  for (const temporaryRef of refs) {
+    const current = await readDirectRef(repoRoot, temporaryRef.ref, runGit);
+    if (current !== temporaryRef.oid) {
+      throw new RuntimeError("temporary slice ref moved during recovery");
+    }
+  }
+  return refs;
+}
+
+async function cleanupTemporarySliceRefs(
+  repoRoot: string,
+  runId: string,
+  runGit: typeof git,
+): Promise<void> {
+  const refs = await temporarySliceRefs(repoRoot, runId, runGit);
+  for (const temporaryRef of refs) {
+    await deleteExactRef(repoRoot, temporaryRef.ref, temporaryRef.oid, runGit);
+  }
 }
 
 function parseCleanupRecord(line: string): CleanupRecord {
@@ -489,6 +633,7 @@ async function recoverRun(
   requestCooperativeTermination: (pid: number) => void | Promise<void>,
   delayMs: (ms: number) => Promise<void>,
   graceMs: number,
+  runGit: typeof git,
 ): Promise<void> {
   let escalation: "cooperative" | "forced" | undefined;
   if (record.pid !== null && isProcessAlive(record.pid)) {
@@ -512,19 +657,8 @@ async function recoverRun(
     "recovery",
     "startup recovery reclaimed unfinished run\n",
   );
-  for (const managedId of [
-    record.runId,
-    `baseline-${record.runId}`,
-    `verify-${record.runId}`,
-    `${record.runId}-pipeline`,
-    `${record.runId}-verify`,
-  ]) {
-    const worktreePath = path.join(root, "worktrees", managedId);
-    const worktreeIdentity = await plainDirectoryIdentity(worktreePath);
-    if (worktreeIdentity !== null) {
-      await new WorktreeManager(commonDir, managedId, ps).remove(worktreePath);
-    }
-  }
+  await cleanupManagedWorktrees(commonDir, root, record.runId, ps);
+  await cleanupTemporarySliceRefs(commonDir, record.runId, runGit);
   await removeStaleCandidateAnchor(commonDir, record.runId);
   await store.writeResult({
     resultVersion: "1",
@@ -656,6 +790,7 @@ export async function recoverStaleRuns(
     ?? defaultRequestCooperativeTermination;
   const delayMs = dependencies.delayMs ?? defaultDelayMs;
   const graceMs = dependencies.graceMs ?? 3000;
+  const runGit = dependencies.git ?? git;
   const locksRoot = path.join(root, "locks");
   const stale: RunStartRecord[] = [];
   if (runsIdentity !== null) {
@@ -677,15 +812,9 @@ export async function recoverStaleRuns(
           pid => ps.getProcessStartToken(pid),
         )) {
           const commonDir = await validateGitCommonDir(record.canonicalCommonDir);
-          for (const managedId of [
-            `${entry.name}-pipeline`,
-            `${entry.name}-verify`,
-          ]) {
-            const worktreePath = path.join(root, "worktrees", managedId);
-            if (await plainDirectoryIdentity(worktreePath) !== null) {
-              await new WorktreeManager(commonDir, managedId, ps).remove(worktreePath);
-            }
-          }
+          await archiveInterruptedPipeline(store, result);
+          await cleanupManagedWorktrees(commonDir, root, entry.name, ps);
+          await cleanupTemporarySliceRefs(commonDir, entry.name, runGit);
           await store.clearPipelineActiveMarker();
         }
         continue;
@@ -710,6 +839,7 @@ export async function recoverStaleRuns(
       requestCooperativeTermination,
       delayMs,
       graceMs,
+      runGit,
     );
     recovered.push(record.runId);
   }

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -59,7 +59,8 @@ interface DirectoryIdentity {
 }
 
 export interface RecoveryDependencies {
-  platformServices?: Pick<PlatformServices, "os" | "getProcessStartToken" | "terminateProcessTreeByPid">;
+  platformServices?: Pick<PlatformServices, "os" | "getProcessStartToken" | "terminateProcessTreeByPid">
+    & Partial<Pick<PlatformServices, "acquireCheckoutLock">>;
   isProcessAlive?: (pid: number) => boolean;
   requestCooperativeTermination?: (pid: number) => void | Promise<void>;
   delayMs?: (ms: number) => Promise<void>;
@@ -486,11 +487,17 @@ function parseCleanupRecord(line: string): CleanupRecord {
   const hasRepository = typeof record.repoRoot === "string"
     && typeof record.anchorRef === "string"
     && typeof record.candidateCommitOid === "string";
+  // A candidate-null prune records the repository root for lease serialization
+  // but has no anchor to reconcile: repoRoot set, every Git ref field null.
+  const repositoryOnly = typeof record.repoRoot === "string"
+    && record.anchorRef === null
+    && record.backupRef === null
+    && record.candidateCommitOid === null;
   const noRepository = record.repoRoot === null
     && record.anchorRef === null
     && record.backupRef === null
     && record.candidateCommitOid === null;
-  if (!noRepository && (!hasRepository
+  if (!noRepository && !repositoryOnly && (!hasRepository
     || record.anchorRef !== `${CANDIDATE_REF_PREFIX}${record.runId}`
     || !OID.test(record.candidateCommitOid as string)
     || (record.backupRef !== null
@@ -501,7 +508,7 @@ function parseCleanupRecord(line: string): CleanupRecord {
 }
 
 function cleanupOutcome(record: CleanupRecord): AnchorCleanup {
-  if (record.repoRoot === null) return "not-applicable";
+  if (record.repoRoot === null || record.anchorRef === null) return "not-applicable";
   return record.backupRef === null ? "already-absent" : "deleted";
 }
 
@@ -590,7 +597,10 @@ async function commitCleanupRefs(record: CleanupRecord): Promise<void> {
   await deleteExactRef(repoRoot, record.backupRef!, backupOid);
 }
 
-async function replayInterruptedPrunes(runsRoot: string): Promise<void> {
+async function replayInterruptedPrunes(
+  runsRoot: string,
+  ps: Pick<PlatformServices, "acquireCheckoutLock">,
+): Promise<void> {
   const text = await readCleanupJournal(path.join(runsRoot, "cleanup.ndjson"));
   if (text === null || text.trim() === "") return;
   const pending = new Map<string, CleanupRecord>();
@@ -603,40 +613,78 @@ async function replayInterruptedPrunes(runsRoot: string): Promise<void> {
 
   for (const record of [...pending.values()].sort((left, right) =>
     left.runId.localeCompare(right.runId))) {
-    const runDirectory = path.join(runsRoot, record.runId);
-    const quarantinePath = path.join(runsRoot, record.quarantineName);
-    const runIdentity = await plainDirectoryIdentity(runDirectory);
-    const quarantineIdentity = await plainDirectoryIdentity(quarantinePath);
-    if (runIdentity !== null && quarantineIdentity !== null) {
-      throw new RuntimeError("both retained and quarantined run archives exist during recovery");
+    // A repoRoot-less legacy intent has neither anchor nor repository to lock.
+    if (record.repoRoot === null) continue;
+    // Serialize the archive/anchor reconciliation against the checkout
+    // lifecycle: hold the repository's checkout lease exactly as prune did.
+    const repoRoot = await validateRepositoryRoot(record.repoRoot);
+    const commonResult = await git(repoRoot, [
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-common-dir",
+    ]);
+    if (commonResult.exitCode !== 0) {
+      throw runGitError("resolve cleanup repository identity", commonResult);
     }
-    const action = runIdentity !== null ? "rollback" : "finish";
-    const outcome = await reconcileCleanupRefs(record, action);
-    if (action === "finish") {
-      if (quarantineIdentity !== null) {
-        await removePlainDirectory(quarantinePath, quarantineIdentity);
+    const repositoryIdentity = await realpath(commonResult.stdout.trim());
+    const lease = await ps.acquireCheckoutLock(repoRoot);
+    let primaryError: unknown;
+    try {
+      if (lease.repositoryIdentity !== repositoryIdentity) {
+        throw new RuntimeError("checkout lease repository identity changed during prune recovery");
       }
-      await commitCleanupRefs(record);
+      const runDirectory = path.join(runsRoot, record.runId);
+      const quarantinePath = path.join(runsRoot, record.quarantineName);
+      const runIdentity = await plainDirectoryIdentity(runDirectory);
+      const quarantineIdentity = await plainDirectoryIdentity(quarantinePath);
+      if (runIdentity !== null && quarantineIdentity !== null) {
+        throw new RuntimeError("both retained and quarantined run archives exist during recovery");
+      }
+      const action = runIdentity !== null ? "rollback" : "finish";
+      const outcome = await reconcileCleanupRefs(record, action);
+      if (action === "finish") {
+        if (quarantineIdentity !== null) {
+          await removePlainDirectory(quarantinePath, quarantineIdentity);
+        }
+        await commitCleanupRefs(record);
+      }
+      await appendCleanupRecord(runsRoot, {
+        ...record,
+        event: action === "finish" ? "prune-cleanup-complete" : "prune-cleanup-rollback",
+        anchorCleanup: outcome,
+        recordedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      primaryError = error;
+    } finally {
+      try {
+        await lease.release();
+      } catch (releaseError) {
+        if (primaryError !== undefined) {
+          throw new AggregateError(
+            [primaryError, releaseError],
+            "prune recovery failed and its checkout lease could not be released",
+          );
+        }
+        throw releaseError;
+      }
     }
-    await appendCleanupRecord(runsRoot, {
-      ...record,
-      event: action === "finish" ? "prune-cleanup-complete" : "prune-cleanup-rollback",
-      anchorCleanup: outcome,
-      recordedAt: new Date().toISOString(),
-    });
+    if (primaryError !== undefined) throw primaryError;
   }
 }
 
 async function recoverRun(
   record: RunStartRecord,
   root: string,
-  ps: Pick<PlatformServices, "os" | "getProcessStartToken" | "terminateProcessTreeByPid">,
+  ps: Pick<PlatformServices,
+    "os" | "getProcessStartToken" | "terminateProcessTreeByPid" | "acquireCheckoutLock">,
   isProcessAlive: (pid: number) => boolean,
   requestCooperativeTermination: (pid: number) => void | Promise<void>,
   delayMs: (ms: number) => Promise<void>,
   graceMs: number,
   runGit: typeof git,
-): Promise<void> {
+  locksRoot: string,
+): Promise<boolean> {
   let escalation: "cooperative" | "forced" | undefined;
   if (record.pid !== null && isProcessAlive(record.pid)) {
     const liveToken = record.processToken === null
@@ -653,38 +701,107 @@ async function recoverRun(
       }
     }
   }
-  const commonDir = await validateGitCommonDir(record.canonicalCommonDir);
-  const store = new ArtifactStore(record.runId);
-  const logsRef = await store.writeLog(
-    "recovery",
-    "startup recovery reclaimed unfinished run\n",
+  await reclaimExactLock(
+    locksRoot,
+    record.lockKey,
+    isProcessAlive,
+    pid => ps.getProcessStartToken(pid),
   );
-  await cleanupManagedWorktrees(commonDir, root, record.runId, ps);
-  await cleanupTemporarySliceRefs(commonDir, record.runId, runGit);
-  await removeStaleCandidateAnchor(commonDir, record.runId);
-  await store.writeResult({
-    resultVersion: "1",
-    runId: record.runId,
-    status: "cancelled",
-    failure: "cancelled",
-    summary: "Interrupted attempt was cancelled during startup recovery.",
-    producerSummary: null,
-    candidate: null,
-    requestedVerification: [],
-    executedVerification: [],
-    unresolvedIssues: ["attempt-interrupted-before-terminal-result"],
-    evidence: {
-      recovery: "startup-stale-run",
-      originalStartedAt: record.startedAt,
-      ...(escalation === undefined ? {} : { escalation }),
-    },
-    logsRef,
-    producerId: null,
-    producerVersion: null,
-    producerModel: null,
-    durationMs: Math.max(0, Date.now() - Date.parse(record.startedAt)),
-    sessionId: null,
-  });
+  const commonDir = await validateGitCommonDir(record.canonicalCommonDir);
+  // Serialize the mutating recovery against the checkout lifecycle. Every
+  // authority — run-start owner, terminal result, active marker — is re-read
+  // under the lease, so a run that finishes or is replaced while we wait is
+  // preserved rather than blindly cancelled.
+  const lease = await ps.acquireCheckoutLock(commonDir);
+  let primaryError: unknown;
+  let recovered = false;
+  try {
+    if (lease.repositoryIdentity !== commonDir) {
+      throw new RuntimeError("checkout lease repository identity changed during recovery");
+    }
+    const store = new ArtifactStore(record.runId);
+    const currentRunStartText = await readBoundedRegularFile(
+      path.join(store.runDirectory, "run-start.json"),
+    );
+    if (currentRunStartText === null) return false;
+    const currentRecord = parseRunStart(currentRunStartText, record.runId);
+    if (currentRecord.canonicalCommonDir !== commonDir || currentRecord.lockKey !== record.lockKey) {
+      throw new RuntimeError("run-start repository identity changed during recovery");
+    }
+    const result = await store.readResult(record.runId);
+    const marker = await store.readPipelineActiveMarker(record.runId);
+    if (marker !== null && await lockOwnerIsLive(
+      { pid: marker.pid, processToken: marker.processToken },
+      isProcessAlive,
+      pid => ps.getProcessStartToken(pid),
+    )) return false;
+    if (result !== null) {
+      validateTerminalResult(result, record.runId);
+      if (marker === null) return false;
+      if (marker.sliced) await archiveInterruptedPipeline(store, result);
+      await cleanupManagedWorktrees(commonDir, root, record.runId, ps);
+      await cleanupTemporarySliceRefs(commonDir, record.runId, runGit);
+      await store.clearPipelineActiveMarker();
+      return false;
+    }
+    if (currentRecord.pid !== null && isProcessAlive(currentRecord.pid)) {
+      const token = currentRecord.processToken === null
+        ? null
+        : await ps.getProcessStartToken(currentRecord.pid);
+      const ownerIsLive = currentRecord.processToken === null || token === currentRecord.processToken;
+      const isExactTerminatedOwner = escalation !== undefined
+        && currentRecord.pid === record.pid
+        && currentRecord.processToken === record.processToken;
+      if (ownerIsLive && !isExactTerminatedOwner) return false;
+    }
+    const logsRef = await store.writeLog(
+      "recovery",
+      "startup recovery reclaimed unfinished run\n",
+    );
+    await cleanupManagedWorktrees(commonDir, root, record.runId, ps);
+    await cleanupTemporarySliceRefs(commonDir, record.runId, runGit);
+    await removeStaleCandidateAnchor(commonDir, record.runId);
+    await store.writeResult({
+      resultVersion: "1",
+      runId: record.runId,
+      status: "cancelled",
+      failure: "cancelled",
+      summary: "Interrupted attempt was cancelled during startup recovery.",
+      producerSummary: null,
+      candidate: null,
+      requestedVerification: [],
+      executedVerification: [],
+      unresolvedIssues: ["attempt-interrupted-before-terminal-result"],
+      evidence: {
+        recovery: "startup-stale-run",
+        originalStartedAt: record.startedAt,
+        ...(escalation === undefined ? {} : { escalation }),
+      },
+      logsRef,
+      producerId: null,
+      producerVersion: null,
+      producerModel: null,
+      durationMs: Math.max(0, Date.now() - Date.parse(record.startedAt)),
+      sessionId: null,
+    });
+    recovered = true;
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    try {
+      await lease.release();
+    } catch (releaseError) {
+      if (primaryError !== undefined) {
+        throw new AggregateError(
+          [primaryError, releaseError],
+          "startup recovery failed and its checkout lease could not be released",
+        );
+      }
+      throw releaseError;
+    }
+  }
+  if (primaryError !== undefined) throw primaryError;
+  return recovered;
 }
 
 function defaultRequestCooperativeTermination(pid: number): void {
@@ -757,13 +874,47 @@ async function reclaimLocks(
     }
     const contents = await readBoundedRegularFile(lockPath);
     if (contents === null) continue;
-    if (await lockOwnerIsLive(parseLockOwner(contents), isProcessAlive, getProcessStartToken)) continue;
-    const identity = await lstat(lockPath);
-    if (!identity.isFile() || identity.isSymbolicLink()) {
+    const owner = parseLockOwner(contents);
+    // A malformed lock has no verifiable owner; preserve it rather than
+    // unlinking a file whose identity we cannot reason about.
+    if (owner === null
+      || await lockOwnerIsLive(owner, isProcessAlive, getProcessStartToken)) continue;
+    if (!await lockIsStableRegularFile(lockPath, contents)) {
       throw new RuntimeError("checkout lock identity changed during recovery");
     }
     await rm(lockPath, { force: false });
   }
+}
+
+// A dead-owner lock may only be unlinked when it is a stable regular file whose
+// bytes did not change across the liveness check (guards a concurrent re-lock).
+async function lockIsStableRegularFile(lockPath: string, expected: string): Promise<boolean> {
+  const before = await lstat(lockPath);
+  const current = await readBoundedRegularFile(lockPath);
+  if (current === null) return false;
+  const after = await lstat(lockPath);
+  return before.isFile() && !before.isSymbolicLink()
+    && after.isFile() && !after.isSymbolicLink()
+    && before.dev === after.dev && before.ino === after.ino
+    && current === expected;
+}
+
+async function reclaimExactLock(
+  locksRoot: string,
+  lockKey: string,
+  isProcessAlive: (pid: number) => boolean,
+  getProcessStartToken: (pid: number) => Promise<string | null>,
+): Promise<void> {
+  const lockPath = path.join(locksRoot, `${lockKey}.lock`);
+  const contents = await readBoundedRegularFile(lockPath);
+  if (contents === null) return;
+  const owner = parseLockOwner(contents);
+  if (owner === null
+    || await lockOwnerIsLive(owner, isProcessAlive, getProcessStartToken)) return;
+  if (!await lockIsStableRegularFile(lockPath, contents)) {
+    throw new RuntimeError("checkout lock identity changed during recovery");
+  }
+  await rm(lockPath, { force: false });
 }
 
 async function lockIsOwnedByLiveProcess(
@@ -784,9 +935,25 @@ export async function recoverStaleRuns(
   if (root === null) return { recovered: [] };
   const runsRoot = path.join(root, "runs");
   const runsIdentity = await plainDirectoryIdentity(runsRoot);
-  if (runsIdentity !== null) await replayInterruptedPrunes(runsRoot);
 
-  const ps = dependencies.platformServices ?? getPlatformServices();
+  // Recovery needs a checkout lease. Injected test doubles may omit
+  // acquireCheckoutLock, so fall back to the selected platform for that one
+  // capability while honoring every capability the caller did supply.
+  const supplied = dependencies.platformServices;
+  const selected = getPlatformServices();
+  const ps: Pick<PlatformServices,
+    "os" | "getProcessStartToken" | "terminateProcessTreeByPid" | "acquireCheckoutLock"> = {
+    os: supplied?.os ?? selected.os,
+    getProcessStartToken: pid => (supplied ?? selected).getProcessStartToken(pid),
+    terminateProcessTreeByPid: (pid, token) =>
+      (supplied ?? selected).terminateProcessTreeByPid(pid, token),
+    acquireCheckoutLock: checkout =>
+      supplied && supplied.acquireCheckoutLock
+        ? supplied.acquireCheckoutLock(checkout)
+        : selected.acquireCheckoutLock(checkout),
+  };
+  if (runsIdentity !== null) await replayInterruptedPrunes(runsRoot, ps);
+
   const isProcessAlive = dependencies.isProcessAlive ?? defaultIsProcessAlive;
   const requestCooperativeTermination = dependencies.requestCooperativeTermination
     ?? defaultRequestCooperativeTermination;
@@ -805,22 +972,18 @@ export async function recoverStaleRuns(
       const record = parseRunStart(runStartText, entry.name);
       const store = new ArtifactStore(entry.name);
       const result = await store.readResult(entry.name);
-      if (result !== null) {
-        validateTerminalResult(result, entry.name);
-        const marker = await store.readPipelineActiveMarker(entry.name);
-        if (marker !== null && !await lockOwnerIsLive(
-          { pid: marker.pid, processToken: marker.processToken },
-          isProcessAlive,
-          pid => ps.getProcessStartToken(pid),
-        )) {
-          const commonDir = await validateGitCommonDir(record.canonicalCommonDir);
-          if (marker.sliced) await archiveInterruptedPipeline(store, result);
-          await cleanupManagedWorktrees(commonDir, root, entry.name, ps);
-          await cleanupTemporarySliceRefs(commonDir, entry.name, runGit);
-          await store.clearPipelineActiveMarker();
-        }
-        continue;
-      }
+      if (result !== null) validateTerminalResult(result, entry.name);
+      // A clean terminal run (result, no active marker) needs nothing. A
+      // terminal run whose pipeline marker is still live is untouched. Every
+      // other case is stale and reconciled under the checkout lease in
+      // recoverRun, which re-reads all authority before mutating.
+      const marker = result === null ? null : await store.readPipelineActiveMarker(entry.name);
+      if (result !== null && marker === null) continue;
+      if (marker !== null && await lockOwnerIsLive(
+        { pid: marker.pid, processToken: marker.processToken },
+        isProcessAlive,
+        pid => ps.getProcessStartToken(pid),
+      )) continue;
       if (await lockIsOwnedByLiveProcess(
         locksRoot,
         record.lockKey,
@@ -833,7 +996,7 @@ export async function recoverStaleRuns(
 
   const recovered: string[] = [];
   for (const record of stale) {
-    await recoverRun(
+    if (await recoverRun(
       record,
       root,
       ps,
@@ -842,8 +1005,8 @@ export async function recoverStaleRuns(
       delayMs,
       graceMs,
       runGit,
-    );
-    recovered.push(record.runId);
+      locksRoot,
+    )) recovered.push(record.runId);
   }
   await reclaimLocks(
     locksRoot,

--- a/src/verify/project-verifier.ts
+++ b/src/verify/project-verifier.ts
@@ -330,9 +330,10 @@ export async function projectVerify(args: ProjectVerifyArgs): Promise<ProjectVer
   const artifactRunId = args.artifact.anchorRef.startsWith(anchorPrefix)
     ? args.artifact.anchorRef.slice(anchorPrefix.length)
     : args.artifact.candidateCommitOid;
+  const verificationId = args.runId ?? args.verificationId?.() ?? artifactRunId;
   const manager = new WorktreeManager(
     args.repoRoot,
-    `verify-${args.runId ?? artifactRunId}`,
+    `verify-${verificationId}`,
     ps,
   );
   const materialized = await manager.create(args.artifact.candidateCommitOid);

--- a/tests/runtime/artifact-store.test.ts
+++ b/tests/runtime/artifact-store.test.ts
@@ -7,6 +7,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   rename,
   rm,
   stat,
@@ -142,6 +143,23 @@ async function git(cwd: string, args: string[]): Promise<string> {
     }),
   });
   return result.stdout.trim();
+}
+
+// Prune now serializes archive removal against the repository checkout lease,
+// which requires a run manifest to resolve the repository root. Give a run a
+// real repository plus manifest so it is eligible for the full prune path.
+async function writePrunableResult(
+  store: ArtifactStore,
+  runId: string,
+  result: AttemptResult,
+): Promise<string> {
+  const repoRoot = await mkdtemp(join(tmpdir(), "claude-architect-prunable-repo-"));
+  temporaryPaths.push(repoRoot);
+  await git(repoRoot, ["init", "-q"]);
+  await git(repoRoot, ["commit", "--allow-empty", "-q", "-m", "base"]);
+  await store.writeResult(result);
+  await store.writeManifest(buildRunManifest(manifestArgs(runId, repoRoot)));
+  return repoRoot;
 }
 
 beforeEach(async () => {
@@ -853,7 +871,7 @@ describe("ArtifactStore", () => {
 
   it("prunes over-age runs", async () => {
     const oldStore = new ArtifactStore("run-old");
-    await oldStore.writeResult(sampleResult("run-old"));
+    await writePrunableResult(oldStore, "run-old", sampleResult("run-old"));
     const oldDirectory = join(process.env.CLAUDE_PLUGIN_DATA!, "runs", "run-old");
     const oldTime = new Date(Date.now() - 60_000);
     await utimes(oldDirectory, oldTime, oldTime);
@@ -864,9 +882,199 @@ describe("ArtifactStore", () => {
     await expect(stat(oldDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("fast-retains an active pipeline marker without acquiring a checkout lease", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "claude-architect-active-prune-repo-"));
+    temporaryPaths.push(repoRoot);
+    await git(repoRoot, ["init", "-q"]);
+    await git(repoRoot, ["commit", "--allow-empty", "-q", "-m", "base"]);
+    const runId = "run-active-prune";
+    const store = new ArtifactStore(runId);
+    await store.writeResult(sampleResult(runId));
+    await store.writeManifest(buildRunManifest(manifestArgs(runId, repoRoot)));
+    await store.writePipelineActiveMarker({
+      pid: 4242,
+      processToken: "test:live",
+      startedAt: new Date().toISOString(),
+      sliced: false,
+    });
+    const oldTime = new Date(Date.now() - 60_000);
+    await utimes(store.runDirectory, oldTime, oldTime);
+
+    const result = await store.prune(
+      { maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER },
+      {
+        platformServices: {
+          async canonicalizePath() { throw new Error("must not canonicalize an active run"); },
+          async acquireCheckoutLock() { throw new Error("must not lock an active run"); },
+        },
+      },
+    );
+
+    expect(result.removed).not.toContain(runId);
+    expect(result.retained).toContainEqual({ runId, reason: "active-run" });
+    await expect(stat(store.runDirectory)).resolves.toBeDefined();
+  });
+
+  it("rereads the active marker under the checkout lease before pruning", async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), "claude-architect-waiting-prune-repo-"));
+    temporaryPaths.push(repoRoot);
+    await git(repoRoot, ["init", "-q"]);
+    await git(repoRoot, ["commit", "--allow-empty", "-q", "-m", "base"]);
+    const commonDir = await realpath(join(repoRoot, ".git"));
+    const runId = "run-active-while-prune-waits";
+    const store = new ArtifactStore(runId);
+    await store.writeResult(sampleResult(runId));
+    await store.writeManifest(buildRunManifest(manifestArgs(runId, repoRoot)));
+    await utimes(store.runDirectory, new Date(Date.now() - 60_000), new Date(Date.now() - 60_000));
+    const events: string[] = [];
+
+    const result = await store.prune(
+      { maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER },
+      {
+        platformServices: {
+          async canonicalizePath(input) {
+            return { input, canonical: repoRoot, gitCommonDir: commonDir };
+          },
+          async acquireCheckoutLock() {
+            events.push("acquire");
+            await store.writePipelineActiveMarker({
+              pid: 4343,
+              processToken: "test:live",
+              startedAt: new Date().toISOString(),
+              sliced: false,
+            });
+            return {
+              key: "test",
+              repositoryIdentity: commonDir,
+              async release() { events.push("release"); },
+            };
+          },
+        },
+      },
+    );
+
+    expect(events).toEqual(["acquire", "release"]);
+    expect(result.removed).not.toContain(runId);
+    expect(result.retained).toContainEqual({ runId, reason: "active-run" });
+    await expect(stat(store.runDirectory)).resolves.toBeDefined();
+  });
+
+  it("retains an archive without journaling when checkout lease acquisition fails", async () => {
+    const runId = "run-prune-acquire-failure";
+    const store = new ArtifactStore(runId);
+    const repoRoot = await writePrunableResult(store, runId, sampleResult(runId));
+    const commonDir = await realpath(join(repoRoot, ".git"));
+    await utimes(store.runDirectory, new Date(0), new Date(0));
+
+    const result = await store.prune(
+      { maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER },
+      {
+        platformServices: {
+          async canonicalizePath(input) {
+            return { input, canonical: repoRoot, gitCommonDir: commonDir };
+          },
+          async acquireCheckoutLock() { throw new Error("lease unavailable"); },
+        },
+      },
+    );
+
+    expect(result.removed).not.toContain(runId);
+    expect(result.retained).toContainEqual({ runId, reason: "lease unavailable" });
+    await expect(stat(store.runDirectory)).resolves.toBeDefined();
+    await expect(readFile(join(process.env.CLAUDE_PLUGIN_DATA!, "runs", "cleanup.ndjson"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("retains latest terminal authority when the result changes while waiting", async () => {
+    const runId = "run-prune-result-changed";
+    const store = new ArtifactStore(runId);
+    const initial = sampleResult(runId);
+    const repoRoot = await writePrunableResult(store, runId, initial);
+    const commonDir = await realpath(join(repoRoot, ".git"));
+    await utimes(store.runDirectory, new Date(0), new Date(0));
+    const replacement = { ...initial, summary: "new terminal authority" };
+
+    const result = await store.prune(
+      { maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER },
+      {
+        platformServices: {
+          async canonicalizePath(input) {
+            return { input, canonical: repoRoot, gitCommonDir: commonDir };
+          },
+          async acquireCheckoutLock() {
+            await rm(join(store.runDirectory, "result.json"));
+            await store.writeResult(replacement);
+            return { key: "test", repositoryIdentity: commonDir, async release() {} };
+          },
+        },
+      },
+    );
+
+    expect(result.removed).not.toContain(runId);
+    expect(result.retained.some(entry => entry.reason.includes("authority changed"))).toBe(true);
+    await expect(store.readResult(runId)).resolves.toEqual(replacement);
+  });
+
+  it("records repository identity for candidate-null cleanup intents", async () => {
+    const runId = "run-null-candidate-intent";
+    const store = new ArtifactStore(runId);
+    const repoRoot = await writePrunableResult(store, runId, sampleResult(runId));
+    await utimes(store.runDirectory, new Date(0), new Date(0));
+
+    const result = await store.prune({ maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER });
+
+    expect(result.removed).toContain(runId);
+    const records = (await readFile(
+      join(process.env.CLAUDE_PLUGIN_DATA!, "runs", "cleanup.ndjson"),
+      "utf8",
+    )).trim().split("\n").map(line => JSON.parse(line) as {
+      event: string; repoRoot: string | null; anchorRef: string | null;
+    });
+    expect(records[0]).toMatchObject({
+      event: "prune-cleanup-intent",
+      repoRoot: await realpath(repoRoot),
+      anchorRef: null,
+    });
+  });
+
+  it("surfaces a checkout lease release failure after a committed removal", async () => {
+    const runId = "run-prune-release-failure";
+    const store = new ArtifactStore(runId);
+    const repoRoot = await writePrunableResult(store, runId, sampleResult(runId));
+    const commonDir = await realpath(join(repoRoot, ".git"));
+    await utimes(store.runDirectory, new Date(0), new Date(0));
+    let releases = 0;
+
+    const result = await store.prune(
+      { maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER },
+      {
+        platformServices: {
+          async canonicalizePath(input) {
+            return { input, canonical: repoRoot, gitCommonDir: commonDir };
+          },
+          async acquireCheckoutLock() {
+            return {
+              key: "test",
+              repositoryIdentity: commonDir,
+              async release() { releases += 1; throw new Error("release failed after removal"); },
+            };
+          },
+        },
+      },
+    );
+
+    expect(releases).toBe(1);
+    expect(result.removed).toContain(runId);
+    expect(result.retained).toContainEqual({
+      runId,
+      reason: "archive removed; checkout lease release failed: release failed after removal",
+    });
+    await expect(stat(store.runDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("enforces the byte limit", async () => {
     const store = new ArtifactStore("run-large");
-    await store.writeResult(sampleResult("run-large"));
+    await writePrunableResult(store, "run-large", sampleResult("run-large"));
     await store.writeLog("large", "x".repeat(1_000));
 
     const result = await store.prune({ maxAgeMs: Number.MAX_SAFE_INTEGER, maxBytes: 0 });
@@ -890,7 +1098,7 @@ describe("ArtifactStore", () => {
 
   it("durably records cleanup before removing an archived run", async () => {
     const store = new ArtifactStore("run-audited");
-    await store.writeResult(sampleResult("run-audited"));
+    await writePrunableResult(store, "run-audited", sampleResult("run-audited"));
     const runDirectory = join(process.env.CLAUDE_PLUGIN_DATA!, "runs", "run-audited");
     const oldTime = new Date(Date.now() - 60_000);
     await utimes(runDirectory, oldTime, oldTime);
@@ -917,7 +1125,7 @@ describe("ArtifactStore", () => {
   it("does not write cleanup intent after the archive root is swapped", async () => {
     const runId = "run-cleanup-root-swap";
     const store = new ArtifactStore(runId);
-    await store.writeResult(sampleResult(runId));
+    await writePrunableResult(store, runId, sampleResult(runId));
     const runsRoot = join(process.env.CLAUDE_PLUGIN_DATA!, "runs");
     const preservedRunsRoot = join(process.env.CLAUDE_PLUGIN_DATA!, "preserved-runs");
     const cleanupJournal = join(runsRoot, "cleanup.ndjson");
@@ -1311,7 +1519,7 @@ describe("ArtifactStore", () => {
 
   it("does not remove a replacement swapped into the quarantine path", async () => {
     const store = new ArtifactStore("run-quarantine-swap");
-    await store.writeResult(sampleResult("run-quarantine-swap"));
+    await writePrunableResult(store, "run-quarantine-swap", sampleResult("run-quarantine-swap"));
     const runsRoot = join(process.env.CLAUDE_PLUGIN_DATA!, "runs");
     const oldTime = new Date(Date.now() - 60_000);
     await utimes(store.runDirectory, oldTime, oldTime);

--- a/tests/runtime/artifact-store.test.ts
+++ b/tests/runtime/artifact-store.test.ts
@@ -549,6 +549,67 @@ describe("ArtifactStore", () => {
     await expect(firstStore.readDecision(runId)).resolves.toEqual(records[winnerIndex]);
   });
 
+  it.each([true, false])("round-trips an explicit sliced=%s pipeline marker", async sliced => {
+    const runId = `run-pipeline-marker-${sliced}`;
+    const store = new ArtifactStore(runId);
+    const marker = {
+      pid: process.pid,
+      processToken: null,
+      startedAt: "2026-07-19T12:00:00.000Z",
+      sliced,
+    };
+    await store.writeLog("lifecycle", "create run directory\n");
+
+    await store.writePipelineActiveMarker(marker);
+
+    await expect(store.readPipelineActiveMarker(runId)).resolves.toEqual(marker);
+  });
+
+  it("normalizes a legacy pipeline marker without sliced to non-sliced", async () => {
+    const runId = "run-pipeline-marker-legacy";
+    const store = new ArtifactStore(runId);
+    await store.writeLog("lifecycle", "create run directory\n");
+    await writeFile(join(store.runDirectory, "pipeline-active.json"), `${JSON.stringify({
+      pid: process.pid,
+      processToken: null,
+      startedAt: "2026-07-19T12:00:00.000Z",
+    })}\n`);
+
+    await expect(store.readPipelineActiveMarker(runId)).resolves.toMatchObject({
+      sliced: false,
+    });
+  });
+
+  it.each([null, "true", 1, {}])(
+    "rejects a malformed present pipeline marker discriminator %#",
+    async sliced => {
+      const runId = "run-pipeline-marker-malformed";
+      const store = new ArtifactStore(runId);
+      await store.writeLog("lifecycle", "create run directory\n");
+      await writeFile(join(store.runDirectory, "pipeline-active.json"), `${JSON.stringify({
+        pid: process.pid,
+        processToken: null,
+        startedAt: "2026-07-19T12:00:00.000Z",
+        sliced,
+      })}\n`);
+
+      await expect(store.readPipelineActiveMarker(runId)).rejects.toThrow(
+        /pipeline-active marker is malformed/i,
+      );
+    },
+  );
+
+  it("rejects a newly written pipeline marker without an explicit discriminator", async () => {
+    const store = new ArtifactStore("run-pipeline-marker-missing-discriminator");
+    await store.writeLog("lifecycle", "create run directory\n");
+
+    await expect(store.writePipelineActiveMarker({
+      pid: process.pid,
+      processToken: null,
+      startedAt: "2026-07-19T12:00:00.000Z",
+    } as never)).rejects.toThrow(/pipeline-active marker is invalid/i);
+  });
+
   it("does not accept a forged result after a validated run directory is swapped", async () => {
     const runId = "run-read-swap";
     const store = new ArtifactStore(runId);

--- a/tests/runtime/attempt-runtime.test.ts
+++ b/tests/runtime/attempt-runtime.test.ts
@@ -244,16 +244,18 @@ function dependencies(
 
 async function borrowedLeaseFixture(repoRoot: string): Promise<{
   ps: PlatformServices;
-  borrowedCheckoutLease: { lock: CheckoutLock; repositoryIdentity: string };
+  borrowedCheckoutLease: CheckoutLock;
   acquireCalls(): number;
   releaseCalls(): number;
 }> {
   const platformServices = getPlatformServices();
   const canonical = await platformServices.canonicalizePath(repoRoot);
+  const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
   let acquireCalls = 0;
   let releaseCalls = 0;
   const lock: CheckoutLock = {
     key: "borrowed-checkout-lock-key",
+    repositoryIdentity,
     async release() {
       releaseCalls += 1;
     },
@@ -266,10 +268,7 @@ async function borrowedLeaseFixture(repoRoot: string): Promise<{
   }) as PlatformServices;
   return {
     ps,
-    borrowedCheckoutLease: {
-      lock,
-      repositoryIdentity: canonical.gitCommonDir ?? canonical.canonical,
-    },
+    borrowedCheckoutLease: lock,
     acquireCalls: () => acquireCalls,
     releaseCalls: () => releaseCalls,
   };
@@ -354,6 +353,7 @@ describe("runAttempt", () => {
             lockHeld = true;
             return {
               key: lock.key,
+              repositoryIdentity: lock.repositoryIdentity,
               release: async () => {
                 releaseCalls += 1;
                 await lock.release();
@@ -399,7 +399,7 @@ describe("runAttempt", () => {
     expect(fixture.acquireCalls()).toBe(0);
     expect(fixture.releaseCalls()).toBe(0);
     expect(await archivedJson(runId, "run-start.json")).toMatchObject({
-      lockKey: fixture.borrowedCheckoutLease.lock.key,
+      lockKey: fixture.borrowedCheckoutLease.key,
     });
   });
 
@@ -473,17 +473,24 @@ describe("runAttempt", () => {
     expect(fixture.releaseCalls()).toBe(0);
   });
 
-  it("rejects a borrowed lease for another repository before Producer execution", async () => {
+  it("rejects a borrowed lock bound to another repository before Producer execution", async () => {
     const repoRoot = await initRepo();
     const fixture = await borrowedLeaseFixture(repoRoot);
-    fixture.borrowedCheckoutLease.repositoryIdentity += "-different-repository";
+    fixture.borrowedCheckoutLease = {
+      ...fixture.borrowedCheckoutLease,
+      repositoryIdentity: `${fixture.borrowedCheckoutLease.repositoryIdentity}-forged-lock-binding`,
+    };
     const adapter = new FakeAdapter();
-    const runId = "run-borrowed-lock-mismatch";
+    const runId = "run-borrowed-lock-binding-mismatch";
 
     await expect(runAttempt(
       repoRoot,
       validSpec(),
-      withBorrowedLease(dependencies(adapter, runId, { ps: fixture.ps }), fixture),
+      withBorrowedLease(dependencies(
+        adapter,
+        runId,
+        { ps: fixture.ps },
+      ), fixture),
     )).rejects.toMatchObject({
       message: "borrowed checkout lease repository identity mismatch",
     });
@@ -874,6 +881,7 @@ describe("runAttempt", () => {
             const lock = await platformServices.acquireCheckoutLock(checkout);
             return {
               key: lock.key,
+              repositoryIdentity: lock.repositoryIdentity,
               release: async () => {
                 await lock.release();
                 lockReleased = true;

--- a/tests/runtime/attempt-runtime.test.ts
+++ b/tests/runtime/attempt-runtime.test.ts
@@ -520,6 +520,37 @@ describe("runAttempt", () => {
     await expectAttemptResourcesCleaned(runId);
   });
 
+  it("awaits onRunStart after durably archiving run-start", async () => {
+    const repoRoot = await initRepo();
+    const runId = "run-start-callback";
+    let callbackAwaited = false;
+    let observedRunStart: Record<string, unknown> | undefined;
+    const callbackCompletion = {
+      then(resolve: () => void, reject: (error: unknown) => void): void {
+        callbackAwaited = true;
+        void archivedJson(runId, "run-start.json").then(record => {
+          observedRunStart = record;
+          resolve();
+        }, reject);
+      },
+    };
+
+    const result = await runAttempt(
+      repoRoot,
+      validSpec(),
+      dependencies(new FakeAdapter(), runId, {
+        onRunStart: () => callbackCompletion as unknown as Promise<void>,
+      }),
+    );
+
+    expect(result.status).toBe("verified-candidate");
+    expect(callbackAwaited).toBe(true);
+    expect(observedRunStart).toMatchObject({
+      runId,
+      pid: null,
+    });
+  });
+
   it("collects repository instructions and packaged verifier provenance by default", async () => {
     const repoRoot = await initRepo();
     const instructionContent = "# Repository instructions\nUse the committed policy.\n";

--- a/tests/runtime/attempt-runtime.test.ts
+++ b/tests/runtime/attempt-runtime.test.ts
@@ -381,6 +381,60 @@ describe("runAttempt", () => {
     expect(releaseCalls).toBe(1);
   });
 
+  it("reports standalone checkout lease drift truthfully and releases its owned lock once", async () => {
+    const repoRoot = await initRepo();
+    const platformServices = getPlatformServices();
+    const canonical = await platformServices.canonicalizePath(repoRoot);
+    const beforeAcquireIdentity = `${canonical.gitCommonDir ?? canonical.canonical}-before-acquire`;
+    const acquisitionIdentity = `${canonical.gitCommonDir ?? canonical.canonical}-at-acquire`;
+    const observations: string[] = [];
+    let acquireCalls = 0;
+    let releaseCalls = 0;
+    let ps: PlatformServices;
+    ps = Object.assign(Object.create(platformServices), {
+      async canonicalizePath(input: string) {
+        const repositoryIdentity = observations.length === 0
+          ? beforeAcquireIdentity
+          : acquisitionIdentity;
+        observations.push(repositoryIdentity);
+        return { input, canonical: canonical.canonical, gitCommonDir: repositoryIdentity };
+      },
+      async acquireCheckoutLock(checkout: string) {
+        acquireCalls += 1;
+        const acquired = await ps.canonicalizePath(checkout);
+        const repositoryIdentity = acquired.gitCommonDir ?? acquired.canonical;
+        return {
+          key: createHash("sha256").update(repositoryIdentity).digest("hex"),
+          repositoryIdentity,
+          async release() { releaseCalls += 1; },
+        };
+      },
+    }) as PlatformServices;
+    const adapter = new FakeAdapter();
+    const runId = "run-owned-lock-identity-drift";
+    let thrown: unknown;
+
+    try {
+      await runAttempt(
+        repoRoot,
+        validSpec(),
+        dependencies(adapter, runId, { ps }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect.soft(thrown).toMatchObject({
+      message: "owned checkout lease repository identity mismatch",
+    });
+    expect.soft(observations).toEqual([beforeAcquireIdentity, acquisitionIdentity]);
+    expect.soft(acquireCalls).toBe(1);
+    expect.soft(releaseCalls).toBe(1);
+    expect.soft(adapter.probeCalls).toBe(0);
+    await expect(access(join(process.env.CLAUDE_PLUGIN_DATA!, "runs", runId)))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("uses a matching borrowed checkout lease without acquiring or releasing it", async () => {
     const repoRoot = await initRepo();
     const fixture = await borrowedLeaseFixture(repoRoot);

--- a/tests/runtime/attempt-runtime.test.ts
+++ b/tests/runtime/attempt-runtime.test.ts
@@ -3,10 +3,12 @@ import { access, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { git } from "../../src/git/git-exec.js";
+import { WorktreeManager } from "../../src/git/worktree-manager.js";
 import { verifyBaseline } from "../../src/verify/baseline-verifier.js";
 import type {
+  CheckoutLock,
   PlatformServices,
   ResolvedExecutable,
 } from "../../src/platform/platform-services.js";
@@ -240,6 +242,48 @@ function dependencies(
   };
 }
 
+async function borrowedLeaseFixture(repoRoot: string): Promise<{
+  ps: PlatformServices;
+  borrowedCheckoutLease: { lock: CheckoutLock; repositoryIdentity: string };
+  acquireCalls(): number;
+  releaseCalls(): number;
+}> {
+  const platformServices = getPlatformServices();
+  const canonical = await platformServices.canonicalizePath(repoRoot);
+  let acquireCalls = 0;
+  let releaseCalls = 0;
+  const lock: CheckoutLock = {
+    key: "borrowed-checkout-lock-key",
+    async release() {
+      releaseCalls += 1;
+    },
+  };
+  const ps = Object.assign(Object.create(platformServices), {
+    async acquireCheckoutLock() {
+      acquireCalls += 1;
+      throw new Error("borrowed attempt acquired a nested checkout lock");
+    },
+  }) as PlatformServices;
+  return {
+    ps,
+    borrowedCheckoutLease: {
+      lock,
+      repositoryIdentity: canonical.gitCommonDir ?? canonical.canonical,
+    },
+    acquireCalls: () => acquireCalls,
+    releaseCalls: () => releaseCalls,
+  };
+}
+
+function withBorrowedLease(
+  deps: AttemptRuntimeDependencies,
+  fixture: Awaited<ReturnType<typeof borrowedLeaseFixture>>,
+): AttemptRuntimeDependencies {
+  return Object.assign(deps, {
+    borrowedCheckoutLease: fixture.borrowedCheckoutLease,
+  });
+}
+
 async function archivedJson(runId: string, name: string): Promise<Record<string, unknown>> {
   return JSON.parse(await readFile(
     join(process.env.CLAUDE_PLUGIN_DATA!, "runs", runId, name),
@@ -294,6 +338,8 @@ describe("runAttempt", () => {
     const platformServices = getPlatformServices();
     let lockHeld = false;
     let lockReleased = false;
+    let acquireCalls = 0;
+    let releaseCalls = 0;
 
     const result = await runAttempt(repoRoot, validSpec(), dependencies(
       new FakeAdapter(),
@@ -303,11 +349,13 @@ describe("runAttempt", () => {
           acquireCheckoutLock: async (
             checkout: Parameters<PlatformServices["acquireCheckoutLock"]>[0],
           ) => {
+            acquireCalls += 1;
             const lock = await platformServices.acquireCheckoutLock(checkout);
             lockHeld = true;
             return {
               key: lock.key,
               release: async () => {
+                releaseCalls += 1;
                 await lock.release();
                 lockHeld = false;
                 lockReleased = true;
@@ -329,6 +377,122 @@ describe("runAttempt", () => {
     expect(result.status).toBe("verified-candidate");
     expect(lockHeld).toBe(false);
     expect(lockReleased).toBe(true);
+    expect(acquireCalls).toBe(1);
+    expect(releaseCalls).toBe(1);
+  });
+
+  it("uses a matching borrowed checkout lease without acquiring or releasing it", async () => {
+    const repoRoot = await initRepo();
+    const fixture = await borrowedLeaseFixture(repoRoot);
+    const runId = "run-borrowed-lock-success";
+
+    const result = await runAttempt(
+      repoRoot,
+      validSpec(),
+      withBorrowedLease(
+        dependencies(new FakeAdapter(), runId, { ps: fixture.ps }),
+        fixture,
+      ),
+    );
+
+    expect(result.status).toBe("verified-candidate");
+    expect(fixture.acquireCalls()).toBe(0);
+    expect(fixture.releaseCalls()).toBe(0);
+    expect(await archivedJson(runId, "run-start.json")).toMatchObject({
+      lockKey: fixture.borrowedCheckoutLease.lock.key,
+    });
+  });
+
+  it("does not release a borrowed checkout lease on a classified early return", async () => {
+    const repoRoot = await initRepo();
+    const fixture = await borrowedLeaseFixture(repoRoot);
+
+    const result = await runAttempt(
+      repoRoot,
+      validSpec(),
+      withBorrowedLease(dependencies(
+        new FakeAdapter({ eligible: false }),
+        "run-borrowed-lock-unavailable",
+        { ps: fixture.ps },
+      ), fixture),
+    );
+
+    expect(result.status).toBe("unavailable");
+    expect(fixture.acquireCalls()).toBe(0);
+    expect(fixture.releaseCalls()).toBe(0);
+  });
+
+  it("does not release a borrowed checkout lease when the attempt throws", async () => {
+    const repoRoot = await initRepo();
+    const fixture = await borrowedLeaseFixture(repoRoot);
+
+    await expect(runAttempt(
+      repoRoot,
+      validSpec(),
+      withBorrowedLease(dependencies(new FakeAdapter(), "run-borrowed-lock-throw", {
+        ps: fixture.ps,
+        baselineVerifier: async () => { throw new Error("baseline infrastructure failed"); },
+      }), fixture),
+    )).rejects.toThrow("baseline infrastructure failed");
+
+    expect(fixture.acquireCalls()).toBe(0);
+    expect(fixture.releaseCalls()).toBe(0);
+  });
+
+  it("does not release a borrowed checkout lease when attempt cleanup fails", async () => {
+    const repoRoot = await initRepo();
+    const fixture = await borrowedLeaseFixture(repoRoot);
+    const create = WorktreeManager.prototype.create;
+    const createSpy = vi.spyOn(WorktreeManager.prototype, "create")
+      .mockImplementationOnce(async function (baseCommitOid) {
+        const worktree = await create.call(this, baseCommitOid);
+        return {
+          ...worktree,
+          async cleanup() {
+            await worktree.cleanup();
+            throw new Error("attempt worktree cleanup failed");
+          },
+        };
+      });
+
+    try {
+      await expect(runAttempt(
+        repoRoot,
+        validSpec(),
+        withBorrowedLease(dependencies(
+          new FakeAdapter(),
+          "run-borrowed-lock-cleanup-failure",
+          { ps: fixture.ps },
+        ), fixture),
+      )).rejects.toThrow("attempt worktree cleanup failed");
+    } finally {
+      createSpy.mockRestore();
+    }
+
+    expect(fixture.acquireCalls()).toBe(0);
+    expect(fixture.releaseCalls()).toBe(0);
+  });
+
+  it("rejects a borrowed lease for another repository before Producer execution", async () => {
+    const repoRoot = await initRepo();
+    const fixture = await borrowedLeaseFixture(repoRoot);
+    fixture.borrowedCheckoutLease.repositoryIdentity += "-different-repository";
+    const adapter = new FakeAdapter();
+    const runId = "run-borrowed-lock-mismatch";
+
+    await expect(runAttempt(
+      repoRoot,
+      validSpec(),
+      withBorrowedLease(dependencies(adapter, runId, { ps: fixture.ps }), fixture),
+    )).rejects.toMatchObject({
+      message: "borrowed checkout lease repository identity mismatch",
+    });
+
+    expect(adapter.probeCalls).toBe(0);
+    expect(fixture.acquireCalls()).toBe(0);
+    expect(fixture.releaseCalls()).toBe(0);
+    await expect(access(join(process.env.CLAUDE_PLUGIN_DATA!, "runs", runId)))
+      .rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("stops on a failing baseline before probing producers", async () => {

--- a/tests/runtime/controlled-integrator.test.ts
+++ b/tests/runtime/controlled-integrator.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { freezeCandidate } from "../../src/git/candidate-tree.js";
 import { git } from "../../src/git/git-exec.js";
 import { applyCandidateTree } from "../../src/integrate/controlled-integrator.js";
+import type { CheckoutLock, PlatformServices } from "../../src/platform/platform-services.js";
+import { getPlatformServices } from "../../src/platform/select-platform.js";
 import type { CandidateArtifact } from "../../src/protocol/attempt-result.js";
 
 const temporaryPaths: string[] = [];
@@ -126,6 +128,236 @@ describe("applyCandidateTree", () => {
     const anchor = await git(f.repoRoot, ["show-ref", "--verify", artifact.anchorRef]);
     expect(anchor.exitCode).not.toBe(0);
   });
+
+  it("acquires and releases one identity-bound lease for standalone integration", async () => {
+    const f = await fixture();
+    await writeFile(path.join(f.worktreePath, "a.txt"), "candidate\n");
+    const artifact = await freeze(f, "standalone-lock-ownership");
+    const platformServices = getPlatformServices();
+    let held = false;
+    let acquireCalls = 0;
+    let releaseCalls = 0;
+    let applyObserved = false;
+    const ps = Object.assign(Object.create(platformServices), {
+      async acquireCheckoutLock(checkout: string): Promise<CheckoutLock> {
+        acquireCalls += 1;
+        const lock = await platformServices.acquireCheckoutLock(checkout);
+        held = true;
+        return {
+          ...lock,
+          async release() {
+            expect(held).toBe(true);
+            releaseCalls += 1;
+            await lock.release();
+            held = false;
+          },
+        };
+      },
+    }) as PlatformServices;
+    integrationHooks.beforeReadTree = async () => {
+      expect(held).toBe(true);
+      applyObserved = true;
+    };
+
+    const result = await applyCandidateTree({
+      repoRoot: f.repoRoot,
+      artifact,
+      expectedArtifactHash: artifact.manifestHash,
+      platformServices: ps,
+    });
+
+    expect(result.integration).toBe("applied");
+    expect(acquireCalls).toBe(1);
+    expect(releaseCalls).toBe(1);
+    expect(applyObserved).toBe(true);
+    expect(held).toBe(false);
+  });
+
+  it("borrows the exact lease through preconditions, apply, postconditions, and anchor deletion", async () => {
+    const f = await fixture();
+    await writeFile(path.join(f.worktreePath, "a.txt"), "candidate\n");
+    const artifact = await freeze(f, "borrowed-lock-lifecycle");
+    const platformServices = getPlatformServices();
+    const ownerLock = await platformServices.acquireCheckoutLock(f.repoRoot);
+    let held = true;
+    let canonicalizeCalls = 0;
+    let nestedAcquireCalls = 0;
+    let borrowedReleaseCalls = 0;
+    const borrowedCheckoutLock: CheckoutLock = {
+      ...ownerLock,
+      async release() {
+        borrowedReleaseCalls += 1;
+        held = false;
+        await ownerLock.release();
+      },
+    };
+    const ps = Object.assign(Object.create(platformServices), {
+      async canonicalizePath(input: string) {
+        expect(held).toBe(true);
+        canonicalizeCalls += 1;
+        return platformServices.canonicalizePath(input);
+      },
+      async acquireCheckoutLock(): Promise<CheckoutLock> {
+        nestedAcquireCalls += 1;
+        throw new Error("borrowed integration acquired a nested checkout lease");
+      },
+    }) as PlatformServices;
+    const stages: string[] = [];
+    integrationHooks.beforeReadTree = async () => {
+      expect(held).toBe(true);
+      stages.push("apply");
+    };
+    integrationHooks.afterWorktreeDiff = async () => {
+      expect(held).toBe(true);
+      stages.push("post-apply");
+    };
+    integrationHooks.beforeAnchorDelete = async () => {
+      expect(held).toBe(true);
+      stages.push("anchor-delete");
+    };
+
+    try {
+      const result = await applyCandidateTree({
+        repoRoot: f.repoRoot,
+        artifact,
+        expectedArtifactHash: artifact.manifestHash,
+        borrowedCheckoutLock,
+        platformServices: ps,
+      });
+
+      expect(result.integration).toBe("applied");
+      expect(held).toBe(true);
+      expect(canonicalizeCalls).toBe(1);
+      expect(nestedAcquireCalls).toBe(0);
+      expect(borrowedReleaseCalls).toBe(0);
+      expect(stages).toEqual(["apply", "post-apply", "anchor-delete"]);
+    } finally {
+      if (held) {
+        held = false;
+        await ownerLock.release();
+      }
+    }
+  }, { timeout: 10_000 });
+
+  it("rejects a borrowed lease for another repository before integration preconditions", async () => {
+    const f = await fixture();
+    await writeFile(path.join(f.worktreePath, "a.txt"), "candidate\n");
+    const artifact = await freeze(f, "borrowed-lock-mismatch");
+    const platformServices = getPlatformServices();
+    const canonical = await platformServices.canonicalizePath(f.repoRoot);
+    let canonicalizeCalls = 0;
+    let acquireCalls = 0;
+    let releaseCalls = 0;
+    const ps = Object.assign(Object.create(platformServices), {
+      async canonicalizePath(input: string) {
+        canonicalizeCalls += 1;
+        return platformServices.canonicalizePath(input);
+      },
+      async acquireCheckoutLock(): Promise<CheckoutLock> {
+        acquireCalls += 1;
+        throw new Error("borrowed integration acquired a nested checkout lease");
+      },
+    }) as PlatformServices;
+    const borrowedCheckoutLock: CheckoutLock = {
+      key: "wrong-repository-lock",
+      repositoryIdentity: `${canonical.gitCommonDir ?? canonical.canonical}-other-repository`,
+      async release() { releaseCalls += 1; },
+    };
+    let thrown: unknown;
+
+    try {
+      await applyCandidateTree({
+        repoRoot: f.repoRoot,
+        artifact,
+        expectedArtifactHash: artifact.manifestHash,
+        borrowedCheckoutLock,
+        platformServices: ps,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect.soft(thrown).toMatchObject({
+      message: "borrowed checkout lease repository identity mismatch",
+    });
+    expect.soft(canonicalizeCalls).toBe(1);
+    expect.soft(acquireCalls).toBe(0);
+    expect.soft(releaseCalls).toBe(0);
+    await expect(readFile(path.join(f.repoRoot, "a.txt"), "utf8")).resolves.toBe("base\n");
+    await expect(runGit(f.repoRoot, ["rev-parse", artifact.anchorRef])).resolves.toBe(
+      artifact.candidateCommitOid,
+    );
+  });
+
+  it.each(["aborted", "conflicted", "thrown"] as const)(
+    "leaves borrowed lease ownership with the caller on a %s path",
+    async outcome => {
+      const f = await fixture();
+      await writeFile(path.join(f.worktreePath, "a.txt"), "candidate\n");
+      const artifact = await freeze(f, `borrowed-lock-${outcome}`);
+      const platformServices = getPlatformServices();
+      const canonical = await platformServices.canonicalizePath(f.repoRoot);
+      let held = true;
+      let canonicalizeCalls = 0;
+      let acquireCalls = 0;
+      let releaseCalls = 0;
+      const ps = Object.assign(Object.create(platformServices), {
+        async canonicalizePath(input: string) {
+          expect(held).toBe(true);
+          canonicalizeCalls += 1;
+          return platformServices.canonicalizePath(input);
+        },
+        async acquireCheckoutLock(): Promise<CheckoutLock> {
+          acquireCalls += 1;
+          throw new Error("borrowed integration acquired a nested checkout lease");
+        },
+      }) as PlatformServices;
+      const borrowedCheckoutLock: CheckoutLock = {
+        key: `borrowed-${outcome}`,
+        repositoryIdentity: canonical.gitCommonDir ?? canonical.canonical,
+        async release() {
+          releaseCalls += 1;
+          held = false;
+        },
+      };
+      if (outcome === "conflicted") {
+        integrationHooks.beforeReadTree = async () => {
+          expect(held).toBe(true);
+          await writeFile(path.join(f.repoRoot, "a.txt"), "racing edit\n");
+        };
+      } else if (outcome === "thrown") {
+        integrationHooks.beforeReadTree = async () => {
+          expect(held).toBe(true);
+          throw new Error("integration hook failed");
+        };
+      }
+
+      const applying = applyCandidateTree({
+        repoRoot: f.repoRoot,
+        artifact,
+        expectedArtifactHash: outcome === "aborted" ? "f".repeat(64) : artifact.manifestHash,
+        borrowedCheckoutLock,
+        platformServices: ps,
+      });
+      if (outcome === "aborted") {
+        await expect(applying).resolves.toEqual({
+          integration: "aborted",
+          detail: "artifact-hash-mismatch",
+        });
+      } else if (outcome === "conflicted") {
+        await expect(applying).resolves.toEqual({
+          integration: "conflicted",
+          detail: "candidate-apply-conflict",
+        });
+      } else {
+        await expect(applying).rejects.toThrow("integration hook failed");
+      }
+      expect.soft(canonicalizeCalls).toBe(1);
+      expect.soft(acquireCalls).toBe(0);
+      expect.soft(releaseCalls).toBe(0);
+      expect.soft(held).toBe(true);
+    },
+  );
 
   it("materializes LF bytes exactly when repository autocrlf is enabled", async () => {
     const f = await fixture();

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -14,6 +14,7 @@ import { git } from "../../src/git/git-exec.js";
 import { WorktreeManager } from "../../src/git/worktree-manager.js";
 import { applyCandidateTree } from "../../src/integrate/controlled-integrator.js";
 import { delegatePipelineOutput } from "../../src/mcp/server.js";
+import { handleIntegrateCandidate } from "../../src/mcp/tools.js";
 import { getPlatformServices } from "../../src/platform/select-platform.js";
 import type {
   AttemptResult,
@@ -673,6 +674,8 @@ describe("runPipeline", () => {
     });
     let initialSpec: DelegationSpec | undefined;
     let implementerArgs: RoleRunArgs | undefined;
+    const temporarySliceRef = `refs/claude-architect/slices/${runId}/slice-2-attempt-0`;
+    let observedTemporaryRef = "";
     const reviewArgs: RoleRunArgs[] = [];
     const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
       if (args.role === "implementer") {
@@ -693,6 +696,7 @@ describe("runPipeline", () => {
         }));
       }
       if (args.role === "reviewer-correctness") {
+        observedTemporaryRef = await runGit(repo, ["rev-parse", "--verify", temporarySliceRef]);
         reviewArgs.push(args);
         return success(fenced(approve));
       }
@@ -742,6 +746,9 @@ describe("runPipeline", () => {
     expect(result.slices[1]?.roleLogRefs).toEqual([
       "logs/role-implementer-slice-2-attempt-0-increment1.log",
     ]);
+    expect(observedTemporaryRef).toBe(result.slices[1]?.candidateCommit);
+    expect((await git(repo, ["rev-parse", "--verify", "--quiet", temporarySliceRef])).exitCode)
+      .not.toBe(0);
     expect(result.slices[1]?.verification?.scopeViolations).toEqual([]);
     expect(result.rounds).toHaveLength(1);
     expect(result.verification?.pass).toBe(true);
@@ -800,6 +807,122 @@ describe("runPipeline", () => {
       .toBe("slice one candidate");
     expect(await runGit(repo, ["show", `${result.finalCandidateCommit}:slice-two.txt`]))
       .toBe("slice two candidate");
+  }, { timeout: 120_000 });
+
+  it("aggregates primary, moved slice-ref, and active-marker cleanup failures", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-cleanup-errors";
+    const spec = slicedSpec();
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const baselineCommit = await runGit(repo, ["rev-parse", "HEAD"]);
+    const temporarySliceRef = `refs/claude-architect/slices/${runId}/slice-2-attempt-0`;
+    const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
+      if (args.role === "implementer") {
+        const candidateCommit = await commitRoleFile(
+          args,
+          "slice-two.txt",
+          "slice two candidate\n",
+        );
+        return success(fenced({
+          reportVersion: "1",
+          candidateCommit,
+          status: "complete",
+          summary: "slice complete",
+        }));
+      }
+      if (args.role === "reviewer-correctness") {
+        const expectedOid = await runGit(repo, ["rev-parse", "--verify", temporarySliceRef]);
+        await runGit(repo, [
+          "update-ref",
+          temporarySliceRef,
+          baselineCommit,
+          expectedOid,
+        ]);
+        throw new Error("primary composed-review failure");
+      }
+      throw new Error(`unexpected role ${args.role}`);
+    };
+    const deps = dependencies({ runId, roleRunner });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    const markerCleanup = vi.spyOn(ArtifactStore.prototype, "clearPipelineActiveMarker")
+      .mockRejectedValueOnce(new Error("active-marker cleanup failure"));
+
+    let thrown: unknown;
+    try {
+      await runPipeline(repo, spec, deps);
+    } catch (error) {
+      thrown = error;
+    }
+
+    const messages: string[] = [];
+    const collectMessages = (error: unknown): void => {
+      if (error instanceof Error) messages.push(error.message);
+      if (error instanceof AggregateError) error.errors.forEach(collectMessages);
+    };
+    collectMessages(thrown);
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect(messages).toContain("primary composed-review failure");
+    expect(messages.some(message => message.includes("delete temporary slice ref"))).toBe(true);
+    expect(messages).toContain("active-marker cleanup failure");
+    expect(markerCleanup).toHaveBeenCalledOnce();
+    expect(await runGit(repo, ["rev-parse", "--verify", temporarySliceRef]))
+      .toBe(baselineCommit);
+  }, { timeout: 120_000 });
+
+  it("archives a temporary-ref cleanup failure before clearing lifecycle authority", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-ref-cleanup-failure";
+    const spec = slicedSpec();
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const baselineCommit = await runGit(repo, ["rev-parse", "HEAD"]);
+    const temporarySliceRef = `refs/claude-architect/slices/${runId}/slice-2-attempt-0`;
+    const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
+      if (args.role === "implementer") {
+        const candidateCommit = await commitRoleFile(
+          args,
+          "slice-two.txt",
+          "slice two candidate\n",
+        );
+        return success(fenced({
+          reportVersion: "1",
+          candidateCommit,
+          status: "complete",
+          summary: "slice complete",
+        }));
+      }
+      if (args.role === "reviewer-correctness") {
+        const expectedOid = await runGit(repo, ["rev-parse", "--verify", temporarySliceRef]);
+        await runGit(repo, [
+          "update-ref",
+          temporarySliceRef,
+          baselineCommit,
+          expectedOid,
+        ]);
+        return success(fenced(approve));
+      }
+      throw new Error(`unexpected role ${args.role}`);
+    };
+    const deps = dependencies({ runId, roleRunner });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+
+    await expect(runPipeline(repo, spec, deps))
+      .rejects.toThrow("delete temporary slice ref");
+
+    const store = new ArtifactStore(runId);
+    await expect(store.readResult(runId)).resolves.toMatchObject({
+      status: "failed",
+      failure: "verification-failure",
+      candidate: expect.any(Object),
+    });
+    await expect(readFile(
+      path.join(store.runDirectory, "pipeline-active.json"),
+      "utf8",
+    )).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await runGit(repo, ["rev-parse", temporarySliceRef])).toBe(baselineCommit);
   }, { timeout: 120_000 });
 
   it("runs independent per-slice reviewers with slice-local evidence and logs", async () => {
@@ -929,6 +1052,288 @@ describe("runPipeline", () => {
       .resolves.toMatchObject({ route: "halt" });
     await expect(store.readPipelineArtifact(runId, "slice-1"))
       .resolves.toMatchObject({ route: "halt" });
+    const archived = await store.readResult(runId);
+    expect(archived).toMatchObject({
+      status: "failed",
+      failure: "verification-failure",
+      candidate: result.attempt.candidate,
+    });
+    expect(result.attempt).toEqual(archived);
+    await store.writeDecision({
+      decision: "accepted",
+      recordedAt: "2026-07-19T12:00:00.000Z",
+    });
+    await expect(handleIntegrateCandidate(
+      repo,
+      runId,
+      result.attempt.candidate!.manifestHash,
+    )).resolves.toEqual({
+      ok: false,
+      error: "candidate-not-verified",
+      diagnostic: "candidate did not complete independent verification",
+    });
+  }, { timeout: 120_000 });
+
+  it("archives a SliceExecutionError as the returned non-integrable attempt", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-role-failure";
+    const spec = slicedSpec();
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "implementer") {
+          return {
+            ok: false,
+            rawOutput: "",
+            failure: "timeout",
+            producerId: "stub",
+          };
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(result).toMatchObject({
+      status: "failed",
+      failure: "timeout",
+      attempt: {
+        status: "failed",
+        failure: "timeout",
+        candidate: null,
+      },
+    });
+    const store = new ArtifactStore(runId);
+    await expect(store.readResult(runId)).resolves.toEqual(result.attempt);
+    await expect(readFile(
+      path.join(store.runDirectory, "pipeline-active.json"),
+      "utf8",
+    )).rejects.toMatchObject({ code: "ENOENT" });
+  }, { timeout: 120_000 });
+
+  it("labels sliced candidate provenance failures as slice implementer failures", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-provenance-label";
+    const spec = slicedSpec();
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "implementer") {
+          return success(fenced({
+            reportVersion: "1",
+            candidateCommit: "d".repeat(40),
+            status: "complete",
+            summary: "reported a nonexistent commit",
+          }));
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(result.gate.reasons).toContain("slice implementer reported a missing candidate commit");
+    expect(result.gate.reasons.some(reason => reason.includes("fix phase"))).toBe(false);
+  }, { timeout: 120_000 });
+
+  it("archives an initial per-slice review error before returning failure", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-initial-review-failure";
+    const spec = slicedSpec(true);
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "reviewer-correctness") {
+          return {
+            ok: false,
+            rawOutput: "",
+            failure: "timeout",
+            producerId: "stub",
+          };
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(result).toMatchObject({
+      status: "failed",
+      failure: "producer-failure",
+      attempt: {
+        status: "failed",
+        failure: "producer-failure",
+        candidate: null,
+      },
+    });
+    await expect(new ArtifactStore(runId).readResult(runId)).resolves.toEqual(result.attempt);
+  }, { timeout: 120_000 });
+
+  it("archives a composed-review failure as the returned non-integrable attempt", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-composed-review-failure";
+    const spec = slicedSpec();
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "implementer") {
+          const candidateCommit = await commitRoleFile(
+            args,
+            "slice-two.txt",
+            "slice two candidate\n",
+          );
+          return success(fenced({
+            reportVersion: "1",
+            candidateCommit,
+            status: "complete",
+            summary: "slice complete",
+          }));
+        }
+        if (args.role === "reviewer-correctness") {
+          return {
+            ok: false,
+            rawOutput: "",
+            failure: "timeout",
+            producerId: "stub",
+          };
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(result).toMatchObject({
+      status: "failed",
+      failure: "producer-failure",
+      attempt: {
+        status: "failed",
+        failure: "producer-failure",
+      },
+    });
+    expect(result.attempt.candidate).toBeNull();
+    await expect(new ArtifactStore(runId).readResult(runId)).resolves.toEqual(result.attempt);
+  }, { timeout: 120_000 });
+
+  it("archives an unexpected final-verification error before clearing lifecycle authority", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-final-verification-error";
+    const spec = slicedSpec();
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "implementer") {
+          const candidateCommit = await commitRoleFile(
+            args,
+            "slice-two.txt",
+            "slice two candidate\n",
+          );
+          return success(fenced({
+            reportVersion: "1",
+            candidateCommit,
+            status: "complete",
+            summary: "slice complete",
+          }));
+        }
+        if (args.role === "reviewer-correctness") return success(fenced(approve));
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    const originalVerify = AcceptanceVerifier.prototype.verify;
+    let verificationCalls = 0;
+    vi.spyOn(AcceptanceVerifier.prototype, "verify").mockImplementation(function (args) {
+      verificationCalls += 1;
+      if (verificationCalls === 3) {
+        return Promise.reject(new Error("final verification infrastructure failed"));
+      }
+      return originalVerify.call(this, args);
+    });
+
+    await expect(runPipeline(repo, spec, deps))
+      .rejects.toThrow("final verification infrastructure failed");
+
+    const store = new ArtifactStore(runId);
+    await expect(store.readResult(runId)).resolves.toMatchObject({
+      status: "failed",
+      failure: "verification-failure",
+      candidate: expect.any(Object),
+    });
+    await expect(readFile(
+      path.join(store.runDirectory, "pipeline-active.json"),
+      "utf8",
+    )).rejects.toMatchObject({ code: "ENOENT" });
+  }, { timeout: 120_000 });
+
+  it("archives a composed-fixer failure as the returned non-integrable attempt", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-composed-fixer-failure";
+    const spec = slicedSpec();
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "implementer") {
+          const candidateCommit = await commitRoleFile(
+            args,
+            "slice-two.txt",
+            "slice two candidate\n",
+          );
+          return success(fenced({
+            reportVersion: "1",
+            candidateCommit,
+            status: "complete",
+            summary: "slice complete",
+          }));
+        }
+        if (args.role === "reviewer-correctness") return success(fenced(blocker));
+        if (args.role === "fixer") {
+          return {
+            ok: false,
+            rawOutput: "",
+            failure: "timeout",
+            producerId: "stub",
+          };
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(result).toMatchObject({
+      status: "failed",
+      failure: "timeout",
+      attempt: {
+        status: "failed",
+        failure: "timeout",
+        candidate: null,
+      },
+    });
+    await expect(new ArtifactStore(runId).readResult(runId)).resolves.toEqual(result.attempt);
   }, { timeout: 120_000 });
 
   it("runs a completed increment, redacts and archives it, then reviews its diff", async () => {

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -14,7 +14,10 @@ import { git } from "../../src/git/git-exec.js";
 import { WorktreeManager } from "../../src/git/worktree-manager.js";
 import { applyCandidateTree } from "../../src/integrate/controlled-integrator.js";
 import { delegatePipelineOutput } from "../../src/mcp/server.js";
-import { handleIntegrateCandidate } from "../../src/mcp/tools.js";
+import {
+  handleDecideCandidate,
+  handleIntegrateCandidate,
+} from "../../src/mcp/tools.js";
 import { getPlatformServices } from "../../src/platform/select-platform.js";
 import type {
   AttemptResult,
@@ -42,12 +45,16 @@ import type { RolePackage } from "../../src/pipeline/role-prompts.js";
 import type { RoleRunArgs, RoleRunResult } from "../../src/pipeline/role-runner.js";
 import { ArtifactStore } from "../../src/runtime/artifact-store.js";
 import { buildRunManifest } from "../../src/runtime/run-manifest.js";
-import type { AcceptanceVerifierLike } from "../../src/runtime/attempt-runtime.js";
+import type {
+  AcceptanceVerifierLike,
+  AttemptRuntimeDependencies,
+} from "../../src/runtime/attempt-runtime.js";
 import {
   clearRegisteredSecrets,
   registerSecretValue,
 } from "../../src/runtime/redaction.js";
 import { recoverStaleRuns } from "../../src/runtime/recovery-manager.js";
+import { initializeRunStart } from "../../src/runtime/run-start.js";
 import { AcceptanceVerifier } from "../../src/verify/acceptance-verifier.js";
 
 const temporaryPaths: string[] = [];
@@ -224,8 +231,22 @@ function attemptResult(runId: string, candidate: CandidateArtifact): AttemptResu
 }
 
 function fakeAttempt(runId: string, edit: (repo: string) => Promise<void>) {
-  return async (repo: string): Promise<AttemptResult> => {
+  return async (
+    repo: string,
+    _spec?: DelegationSpec,
+    deps?: AttemptRuntimeDependencies,
+  ): Promise<AttemptResult> => {
     const baselineCommit = await runGit(repo, ["rev-parse", "HEAD"]);
+    const store = new ArtifactStore(runId);
+    const runStart = await initializeRunStart(store, {
+      runId,
+      lockKey: createHash("sha256").update(repo).digest("hex"),
+      canonicalCommonDir: await realpath(path.join(repo, ".git")),
+      pid: null,
+      processToken: null,
+      startedAt: new Date().toISOString(),
+    });
+    await deps?.onRunStart?.(runStart);
     await edit(repo);
     await runGit(repo, ["add", "-A"]);
     await runGit(repo, ["commit", "-q", "-m", "candidate"]);
@@ -236,7 +257,6 @@ function fakeAttempt(runId: string, edit: (repo: string) => Promise<void>) {
     );
     // Mirror AttemptRuntime, which archives result.json + manifest.json before
     // the pipeline runs; candidate promotion reads and replaces both.
-    const store = new ArtifactStore(runId);
     await store.writeResult(result);
     await store.writeManifest(buildRunManifest({
       runId,
@@ -269,6 +289,20 @@ function dependencies(args: {
       await writeFile(path.join(repo, "a.txt"), "candidate\n");
     })),
   };
+}
+
+async function expectPipelineAuthorityBlocksTools(
+  repo: string,
+  runId: string,
+  manifestHash: string,
+): Promise<void> {
+  const expected = {
+    ok: false,
+    error: "pipeline-active",
+    diagnostic: "the delegation pipeline for this run is still active",
+  };
+  await expect(handleDecideCandidate(repo, runId, "accepted")).resolves.toEqual(expected);
+  await expect(handleIntegrateCandidate(repo, runId, manifestHash)).resolves.toEqual(expected);
 }
 
 function roundReviews(
@@ -664,6 +698,60 @@ describe("pipeline runtime namespaces", () => {
 });
 
 describe("runPipeline", () => {
+  it("establishes sliced lifecycle authority before the initial candidate is created", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-early-marker";
+    let markerBeforeEdit: Awaited<ReturnType<ArtifactStore["readPipelineActiveMarker"]>>;
+
+    const result = await runPipeline(repo, slicedSpec(), dependencies({
+      runId,
+      edit: async checkout => {
+        markerBeforeEdit = await new ArtifactStore(runId).readPipelineActiveMarker(runId);
+        await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+      },
+      roleRunner: async args => {
+        if (args.role === "implementer") {
+          const candidateCommit = await commitRoleFile(
+            args,
+            "slice-two.txt",
+            "slice two candidate\n",
+          );
+          return success(fenced({
+            reportVersion: "1",
+            candidateCommit,
+            status: "complete",
+            summary: "slice complete",
+          }));
+        }
+        if (args.role === "reviewer-correctness") return success(fenced(approve));
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    }));
+
+    expect(result.status).toBe("decision-ready");
+    expect(markerBeforeEdit).toMatchObject({ sliced: true });
+  }, { timeout: 120_000 });
+
+  it("does not archive a sliced candidate when lifecycle authority cannot be established", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-marker-write-failure";
+    let editCalled = false;
+    vi.spyOn(ArtifactStore.prototype, "writePipelineActiveMarker")
+      .mockRejectedValueOnce(new Error("pipeline marker write failed"));
+
+    await expect(runPipeline(repo, slicedSpec(), dependencies({
+      runId,
+      edit: async checkout => {
+        editCalled = true;
+        await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+      },
+      roleRunner: async () => { throw new Error("role runner must not run"); },
+    }))).rejects.toThrow("pipeline marker write failed");
+
+    expect(editCalled).toBe(false);
+    await expect(new ArtifactStore(runId).readResult(runId)).resolves.toBeNull();
+  });
+
   it("advances disjoint slices through private provenance and composed gates", async () => {
     const repo = await initSlicedRepo();
     const runId = "pipeline-slices-advance";
@@ -703,9 +791,9 @@ describe("runPipeline", () => {
       throw new Error(`unexpected role ${args.role}`);
     };
     const deps = dependencies({ runId, roleRunner });
-    deps.runAttempt = async (checkoutPath, receivedSpec) => {
+    deps.runAttempt = async (checkoutPath, receivedSpec, attemptDeps) => {
       initialSpec = structuredClone(receivedSpec);
-      return initialRun(checkoutPath);
+      return initialRun(checkoutPath, receivedSpec, attemptDeps);
     };
     const acceptanceSpy = vi.spyOn(AcceptanceVerifier.prototype, "verify");
 
@@ -809,7 +897,7 @@ describe("runPipeline", () => {
       .toBe("slice two candidate");
   }, { timeout: 120_000 });
 
-  it("aggregates primary, moved slice-ref, and active-marker cleanup failures", async () => {
+  it("retains lifecycle authority when a primary failure coincides with incomplete ref cleanup", async () => {
     const repo = await initSlicedRepo();
     const runId = "pipeline-slices-cleanup-errors";
     const spec = slicedSpec();
@@ -845,9 +933,8 @@ describe("runPipeline", () => {
       throw new Error(`unexpected role ${args.role}`);
     };
     const deps = dependencies({ runId, roleRunner });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
-    const markerCleanup = vi.spyOn(ArtifactStore.prototype, "clearPipelineActiveMarker")
-      .mockRejectedValueOnce(new Error("active-marker cleanup failure"));
+    deps.runAttempt = initialRun;
+    const markerCleanup = vi.spyOn(ArtifactStore.prototype, "clearPipelineActiveMarker");
 
     let thrown: unknown;
     try {
@@ -865,13 +952,15 @@ describe("runPipeline", () => {
     expect(thrown).toBeInstanceOf(AggregateError);
     expect(messages).toContain("primary composed-review failure");
     expect(messages.some(message => message.includes("delete temporary slice ref"))).toBe(true);
-    expect(messages).toContain("active-marker cleanup failure");
-    expect(markerCleanup).toHaveBeenCalledOnce();
+    expect(markerCleanup).not.toHaveBeenCalled();
+    await expect(new ArtifactStore(runId).readPipelineActiveMarker(runId)).resolves.toMatchObject({
+      sliced: true,
+    });
     expect(await runGit(repo, ["rev-parse", "--verify", temporarySliceRef]))
       .toBe(baselineCommit);
   }, { timeout: 120_000 });
 
-  it("archives a temporary-ref cleanup failure before clearing lifecycle authority", async () => {
+  it("archives a temporary-ref cleanup failure but retains lifecycle authority", async () => {
     const repo = await initSlicedRepo();
     const runId = "pipeline-slices-ref-cleanup-failure";
     const spec = slicedSpec();
@@ -907,7 +996,7 @@ describe("runPipeline", () => {
       throw new Error(`unexpected role ${args.role}`);
     };
     const deps = dependencies({ runId, roleRunner });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
 
     await expect(runPipeline(repo, spec, deps))
       .rejects.toThrow("delete temporary slice ref");
@@ -918,11 +1007,54 @@ describe("runPipeline", () => {
       failure: "verification-failure",
       candidate: expect.any(Object),
     });
-    await expect(readFile(
-      path.join(store.runDirectory, "pipeline-active.json"),
-      "utf8",
-    )).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(store.readPipelineActiveMarker(runId)).resolves.toMatchObject({ sliced: true });
+    const archived = await store.readResult(runId);
+    await expectPipelineAuthorityBlocksTools(
+      repo,
+      runId,
+      archived!.candidate!.manifestHash,
+    );
     expect(await runGit(repo, ["rev-parse", temporarySliceRef])).toBe(baselineCommit);
+  }, { timeout: 120_000 });
+
+  it("retains lifecycle authority when terminal failure archival does not complete", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-archive-failure";
+    const spec = slicedSpec(true);
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "reviewer-correctness") {
+          return {
+            ok: false,
+            rawOutput: "",
+            failure: "timeout",
+            producerId: "stub",
+          };
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = initialRun;
+    vi.spyOn(ArtifactStore.prototype, "promoteTerminalArtifacts")
+      .mockRejectedValue(new Error("terminal archive failed"));
+
+    await expect(runPipeline(repo, spec, deps)).rejects.toThrow(
+      "sliced pipeline failed and its attempt result could not be archived",
+    );
+
+    const store = new ArtifactStore(runId);
+    await expect(store.readPipelineActiveMarker(runId)).resolves.toMatchObject({ sliced: true });
+    const archived = await store.readResult(runId);
+    expect(archived).toMatchObject({ status: "verified-candidate" });
+    await expectPipelineAuthorityBlocksTools(
+      repo,
+      runId,
+      archived!.candidate!.manifestHash,
+    );
   }, { timeout: 120_000 });
 
   it("runs independent per-slice reviewers with slice-local evidence and logs", async () => {
@@ -955,7 +1087,7 @@ describe("runPipeline", () => {
       throw new Error(`unexpected role ${args.role}`);
     };
     const deps = dependencies({ runId, roleRunner });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
 
     const result = await runPipeline(repo, spec, deps);
 
@@ -1021,7 +1153,7 @@ describe("runPipeline", () => {
       return success(fenced(approve));
     };
     const deps = dependencies({ runId, roleRunner });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
     const baselineCommit = await runGit(repo, ["rev-parse", "HEAD"]);
 
     const result = await runPipeline(repo, spec, deps);
@@ -1095,7 +1227,7 @@ describe("runPipeline", () => {
         throw new Error(`unexpected role ${args.role}`);
       },
     });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
 
     const result = await runPipeline(repo, spec, deps);
 
@@ -1137,7 +1269,7 @@ describe("runPipeline", () => {
         throw new Error(`unexpected role ${args.role}`);
       },
     });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
 
     const result = await runPipeline(repo, spec, deps);
 
@@ -1166,7 +1298,7 @@ describe("runPipeline", () => {
         throw new Error(`unexpected role ${args.role}`);
       },
     });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
 
     const result = await runPipeline(repo, spec, deps);
 
@@ -1216,7 +1348,7 @@ describe("runPipeline", () => {
         throw new Error(`unexpected role ${args.role}`);
       },
     });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
 
     const result = await runPipeline(repo, spec, deps);
 
@@ -1259,7 +1391,7 @@ describe("runPipeline", () => {
         throw new Error(`unexpected role ${args.role}`);
       },
     });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
     const originalVerify = AcceptanceVerifier.prototype.verify;
     let verificationCalls = 0;
     vi.spyOn(AcceptanceVerifier.prototype, "verify").mockImplementation(function (args) {
@@ -1320,7 +1452,7 @@ describe("runPipeline", () => {
         throw new Error(`unexpected role ${args.role}`);
       },
     });
-    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    deps.runAttempt = initialRun;
 
     const result = await runPipeline(repo, spec, deps);
 
@@ -1909,8 +2041,12 @@ describe("runPipeline", () => {
     );
     let markerObserved = false;
     const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
-      const marker = JSON.parse(await readFile(markerPath, "utf8")) as { pid?: unknown };
+      const marker = JSON.parse(await readFile(markerPath, "utf8")) as {
+        pid?: unknown;
+        sliced?: unknown;
+      };
       expect(marker.pid).toBe(process.pid);
+      expect(marker.sliced).toBe(false);
       markerObserved = true;
       return baseRoleRunner(args);
     };

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { git } from "../../src/git/git-exec.js";
 import { WorktreeManager } from "../../src/git/worktree-manager.js";
 import { applyCandidateTree } from "../../src/integrate/controlled-integrator.js";
@@ -20,16 +20,24 @@ import type {
   CandidateArtifact,
   ChangedPath,
 } from "../../src/protocol/attempt-result.js";
-import type { DelegationSpec } from "../../src/protocol/delegation-spec.js";
+import type { DelegationSpec, Slice } from "../../src/protocol/delegation-spec.js";
 import { ProducerRegistry } from "../../src/producers/producer-registry.js";
 import {
   composeProgressNotes,
   detectWeakenedTests,
+  runIncrement,
   runPipeline,
+  runReviews,
+  scopeSpecToSlice,
+  verifyCandidate,
   type PipelineDependencies,
 } from "../../src/pipeline/pipeline-runtime.js";
-import { resolveLinkedWorktreeWritableRoots } from "../../src/pipeline/git-writable-roots.js";
+import {
+  resolveLinkedWorktreeWritableRoots,
+  type LinkedWorktreeGitAccess,
+} from "../../src/pipeline/git-writable-roots.js";
 import type { IncrementReport, ReviewReport } from "../../src/pipeline/report-types.js";
+import type { RolePackage } from "../../src/pipeline/role-prompts.js";
 import type { RoleRunArgs, RoleRunResult } from "../../src/pipeline/role-runner.js";
 import { ArtifactStore } from "../../src/runtime/artifact-store.js";
 import { buildRunManifest } from "../../src/runtime/run-manifest.js";
@@ -39,6 +47,7 @@ import {
   registerSecretValue,
 } from "../../src/runtime/redaction.js";
 import { recoverStaleRuns } from "../../src/runtime/recovery-manager.js";
+import { AcceptanceVerifier } from "../../src/verify/acceptance-verifier.js";
 
 const temporaryPaths: string[] = [];
 let previousPluginData: string | undefined;
@@ -349,6 +358,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   clearRegisteredSecrets();
   if (previousPluginData === undefined) delete process.env.CLAUDE_PLUGIN_DATA;
   else process.env.CLAUDE_PLUGIN_DATA = previousPluginData;
@@ -399,6 +409,164 @@ describe("composeProgressNotes", () => {
 
     expect(notes).toHaveLength(8_000);
     expect(notes).toMatch(/\[progress notes truncated\]$/);
+  });
+});
+
+describe("scopeSpecToSlice", () => {
+  it("clones the parent with only slice-owned fields replaced and slices removed", async () => {
+    const slice: Slice = {
+      objective: "Implement only the first slice.",
+      context: "The slice context is authoritative.",
+      writeAllowlist: ["src/slice/**"],
+      forbiddenScope: ["src/slice/private/**"],
+      successCriteria: ["The slice is independently complete."],
+      verification: [{
+        id: "slice-check",
+        executable: "node",
+        args: ["-e", "process.exit(0)"],
+        cwd: ".",
+        environment: { SLICE_CHECK: "true" },
+        timeoutMs: 30_000,
+        network: "denied",
+        expectedExitCodes: [0],
+        platform: { os: ["darwin", "linux", "win32"] },
+      }],
+    };
+    const parent: DelegationSpec = {
+      ...validSpec({ reviewers: ["correctness"], maxRounds: 1, focus: ["security"] }),
+      objective: "Complete the whole delegation.",
+      context: "Parent context.",
+      writeAllowlist: ["src/**"],
+      forbiddenScope: ["src/private/**"],
+      successCriteria: ["The entire delegation is complete."],
+      producerOverrides: { model: "trusted-model", reasoningEffort: "high" },
+      implementation: { maxIncrements: 2 },
+      slices: [structuredClone(slice)],
+    };
+    const parentSnapshot = structuredClone(parent);
+    const sliceSnapshot = structuredClone(slice);
+
+    const scoped = scopeSpecToSlice(parent, slice);
+    const expected = structuredClone(parent);
+    Object.assign(expected, slice);
+    delete expected.slices;
+
+    expect(scoped).toEqual(expected);
+    expect(scoped).not.toHaveProperty("slices");
+    scoped.writeAllowlist.push("result-only/**");
+    scoped.verification[0]!.args.push("result-only");
+    scoped.producerPreferences.push("result-only");
+    expect(parent).toEqual(parentSnapshot);
+    expect(slice).toEqual(sliceSnapshot);
+  });
+});
+
+describe("pipeline runtime namespaces", () => {
+  it("derives distinct implementer and reviewer log names from a trusted namespace", async () => {
+    const runId = "pipeline-namespaced-roles";
+    const spec = implementationSpec(2);
+    const pkg: RolePackage = {
+      spec,
+      baselineCommit: "a".repeat(40),
+      candidateCommit: "b".repeat(40),
+      candidateDiff: "",
+      testEvidence: "[]",
+    };
+    const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => args.role === "implementer"
+      ? success(fenced({
+        reportVersion: "1",
+        candidateCommit: pkg.candidateCommit,
+        status: "complete",
+        summary: "slice complete",
+      }))
+      : success(fenced(approve));
+    const deps = dependencies({ runId, roleRunner });
+    const store = new ArtifactStore(runId);
+    const gitObjectAccess: LinkedWorktreeGitAccess = {
+      gitDir: "/git-dir",
+      privateObjectsDir: "/private-objects",
+      sharedObjectsDir: "/shared-objects",
+      writableRoots: [],
+    };
+    const increment = await runIncrement({
+      spec,
+      pkg,
+      worktreePath: "/worktree",
+      deps,
+      runId,
+      increment: 2,
+      store,
+      gitObjectAccess,
+      logNameNamespace: "slice1-attempt0",
+    });
+    const reviews = await runReviews({
+      reviewers: ["correctness"],
+      spec,
+      pkg,
+      worktreePath: "/worktree",
+      deps,
+      runId,
+      round: 1,
+      store,
+      logNameNamespace: "slice1-attempt1",
+    });
+
+    expect(increment.roleLogRefs).toEqual([
+      "logs/role-implementer-slice1-attempt0-increment2.log",
+    ]);
+    expect(reviews.roleLogRefs).toEqual([
+      "logs/role-reviewer-correctness-slice1-attempt1-round1.log",
+    ]);
+  });
+
+  it("derives verification worktree, verifier, and log identities from one namespace", async () => {
+    const repo = await initRepo();
+    const runId = "pipeline-namespaced-verification";
+    const baselineCommit = await runGit(repo, ["rev-parse", "HEAD"]);
+    await writeFile(path.join(repo, "a.txt"), "candidate\n");
+    await runGit(repo, ["add", "a.txt"]);
+    await runGit(repo, ["commit", "-q", "-m", "candidate"]);
+    const candidateCommit = await runGit(repo, ["rev-parse", "HEAD"]);
+    const candidate = await artifactFor(repo, runId, baselineCommit, candidateCommit);
+    const attempt = attemptResult(runId, candidate);
+    const spec = validSpec({ reviewers: ["correctness"], maxRounds: 1 });
+    spec.verification = [{
+      ...spec.verification[0]!,
+      args: [
+        "-e",
+        [
+          "const fs = require('node:fs');",
+          "const path = require('node:path');",
+          "process.stdout.write(fs.readdirSync(path.dirname(process.cwd())).sort().join('\\n'));",
+        ].join(" "),
+      ],
+    }];
+    const store = new ArtifactStore(runId);
+    const verifierSpy = vi.spyOn(AcceptanceVerifier.prototype, "verify");
+
+    const result = await verifyCandidate({
+      checkoutPath: repo,
+      spec,
+      deps: dependencies({
+        runId,
+        roleRunner: async () => { throw new Error("role runner must not run"); },
+      }),
+      attempt,
+      baselineCommit,
+      candidateCommit,
+      store,
+      namespace: "slice1-attempt0",
+    });
+    const stdoutRef = result.verification.evidence.commandOutcomes[0]?.stdoutRef;
+    const verifierArgs = verifierSpy.mock.calls[0]?.[0];
+
+    expect(stdoutRef).toBe("logs/slice1-attempt0-pipeline-verification-0-stdout.log");
+    expect(verifierArgs?.verificationId?.()).toBe(
+      `${runId}-slice1-attempt0-pipeline`,
+    );
+    const worktrees = (await readFile(path.join(store.runDirectory, stdoutRef!), "utf8"))
+      .split("\n");
+    expect(worktrees).toContain(`${runId}-slice1-attempt0-verify`);
   });
 });
 
@@ -989,6 +1157,8 @@ describe("runPipeline", () => {
     );
 
     expect(result.status).toBe("decision-ready");
+    expect(result.slices).toEqual([]);
+    expect(result.haltedSliceIndex).toBeNull();
     expect(markerObserved).toBe(true);
     await expect(readFile(markerPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     expect(result.rounds).toHaveLength(1);
@@ -1594,6 +1764,8 @@ describe("runPipeline", () => {
     });
 
     expect(result.status).toBe("failed");
+    expect(result.slices).toEqual([]);
+    expect(result.haltedSliceIndex).toBeNull();
     expect(result.failure).toBe("verification-failure");
     expect(result.gate.reasons).toContain("implement phase did not produce a verified candidate");
   });

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   readFile,
   realpath,
   rm,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -76,6 +77,11 @@ async function runGit(
   const result = await git(cwd, args, env === undefined ? undefined : { env });
   expect(result.exitCode, result.stderr).toBe(0);
   return result.stdout.trim();
+}
+
+async function expectRefMissing(repo: string, ref: string): Promise<void> {
+  const result = await git(repo, ["rev-parse", "--verify", "--quiet", ref]);
+  expect(result.exitCode).not.toBe(0);
 }
 
 async function initRepo(): Promise<string> {
@@ -238,10 +244,11 @@ function fakeAttempt(runId: string, edit: (repo: string) => Promise<void>) {
   ): Promise<AttemptResult> => {
     const baselineCommit = await runGit(repo, ["rev-parse", "HEAD"]);
     const store = new ArtifactStore(runId);
+    const canonicalCommonDir = await realpath(path.join(repo, ".git"));
     const runStart = await initializeRunStart(store, {
       runId,
-      lockKey: createHash("sha256").update(repo).digest("hex"),
-      canonicalCommonDir: await realpath(path.join(repo, ".git")),
+      lockKey: createHash("sha256").update(canonicalCommonDir).digest("hex"),
+      canonicalCommonDir,
       pid: null,
       processToken: null,
       startedAt: new Date().toISOString(),
@@ -1039,22 +1046,156 @@ describe("runPipeline", () => {
       },
     });
     deps.runAttempt = initialRun;
-    vi.spyOn(ArtifactStore.prototype, "promoteTerminalArtifacts")
-      .mockRejectedValue(new Error("terminal archive failed"));
+    const promotion = vi.spyOn(ArtifactStore.prototype, "promoteTerminalArtifacts")
+      .mockRejectedValueOnce(new Error("terminal archive failed"));
 
     await expect(runPipeline(repo, spec, deps)).rejects.toThrow(
       "sliced pipeline failed and its attempt result could not be archived",
     );
 
     const store = new ArtifactStore(runId);
+    expect(promotion).toHaveBeenCalledOnce();
     await expect(store.readPipelineActiveMarker(runId)).resolves.toMatchObject({ sliced: true });
     const archived = await store.readResult(runId);
     expect(archived).toMatchObject({ status: "verified-candidate" });
+    await expectRefMissing(repo, archived!.candidate!.anchorRef);
     await expectPipelineAuthorityBlocksTools(
       repo,
       runId,
       archived!.candidate!.manifestHash,
     );
+
+    promotion.mockRestore();
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+
+    await expect(store.readResult(runId)).resolves.toMatchObject({
+      status: "failed",
+      failure: "verification-failure",
+      candidate: expect.any(Object),
+    });
+    await expect(store.readPipelineActiveMarker(runId)).resolves.toBeNull();
+    await expectRefMissing(repo, archived!.candidate!.anchorRef);
+    const oldTime = new Date(Date.now() - 60_000);
+    await utimes(store.runDirectory, oldTime, oldTime);
+    await expect(store.prune({
+      maxAgeMs: 1_000,
+      maxBytes: Number.MAX_SAFE_INTEGER,
+    })).resolves.toMatchObject({ removed: [runId] });
+    await expect(store.readResult(runId)).resolves.toBeNull();
+  }, { timeout: 120_000 });
+
+  it("refuses candidate-null archival when the exact run anchor moved", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-moved-failure-anchor";
+    const spec = slicedSpec(true);
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const movedOid = await runGit(repo, ["rev-parse", "HEAD"]);
+    const anchorRef = `refs/claude-architect/candidates/${runId}`;
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "reviewer-correctness") {
+          const expectedOid = await runGit(repo, ["rev-parse", anchorRef]);
+          await runGit(repo, ["update-ref", anchorRef, movedOid, expectedOid]);
+          return {
+            ok: false,
+            rawOutput: "",
+            failure: "timeout",
+            producerId: "stub",
+          };
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = initialRun;
+
+    let thrown: unknown;
+    try {
+      await runPipeline(repo, spec, deps);
+    } catch (error) {
+      thrown = error;
+    }
+
+    const messages: string[] = [];
+    const collectMessages = (error: unknown): void => {
+      if (error instanceof Error) messages.push(error.message);
+      if (error instanceof AggregateError) error.errors.forEach(collectMessages);
+    };
+    collectMessages(thrown);
+    expect(messages.some(message => message.includes("delete sliced candidate anchor"))).toBe(true);
+    expect(await runGit(repo, ["rev-parse", anchorRef])).toBe(movedOid);
+    const store = new ArtifactStore(runId);
+    const archived = await store.readResult(runId);
+    expect(archived).toMatchObject({ status: "verified-candidate" });
+    await expect(store.readPipelineActiveMarker(runId)).resolves.toMatchObject({ sliced: true });
+    await expectPipelineAuthorityBlocksTools(
+      repo,
+      runId,
+      archived!.candidate!.manifestHash,
+    );
+  }, { timeout: 120_000 });
+
+  it("refuses candidate-null archival for a noncanonical candidate anchor", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-noncanonical-failure-anchor";
+    const spec = slicedSpec(true);
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const canonicalRef = `refs/claude-architect/candidates/${runId}`;
+    const foreignRef = `${canonicalRef}-foreign`;
+    const deps = dependencies({
+      runId,
+      roleRunner: async args => {
+        if (args.role === "reviewer-correctness") {
+          return {
+            ok: false,
+            rawOutput: "",
+            failure: "timeout",
+            producerId: "stub",
+          };
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.runAttempt = async (checkoutPath, receivedSpec, attemptDeps) => {
+      const result = await initialRun(checkoutPath, receivedSpec, attemptDeps);
+      await runGit(repo, ["update-ref", foreignRef, result.candidate!.candidateCommitOid]);
+      return {
+        ...result,
+        candidate: { ...result.candidate!, anchorRef: foreignRef },
+      };
+    };
+
+    let thrown: unknown;
+    try {
+      await runPipeline(repo, spec, deps);
+    } catch (error) {
+      thrown = error;
+    }
+
+    const messages: string[] = [];
+    const collectMessages = (error: unknown): void => {
+      if (error instanceof Error) messages.push(error.message);
+      if (error instanceof AggregateError) error.errors.forEach(collectMessages);
+    };
+    collectMessages(thrown);
+    expect(messages).toContain("sliced candidate anchor does not match run id");
+
+    const canonicalOid = await runGit(repo, ["rev-parse", canonicalRef]);
+    expect(await runGit(repo, ["rev-parse", foreignRef])).toBe(canonicalOid);
+    const store = new ArtifactStore(runId);
+    await expect(store.readResult(runId)).resolves.toMatchObject({ status: "verified-candidate" });
+    await expect(store.readPipelineActiveMarker(runId)).resolves.toMatchObject({ sliced: true });
   }, { timeout: 120_000 });
 
   it("runs independent per-slice reviewers with slice-local evidence and logs", async () => {
@@ -1191,6 +1332,8 @@ describe("runPipeline", () => {
       candidate: result.attempt.candidate,
     });
     expect(result.attempt).toEqual(archived);
+    expect(await runGit(repo, ["rev-parse", result.attempt.candidate!.anchorRef]))
+      .toBe(result.attempt.candidate!.candidateCommitOid);
     await store.writeDecision({
       decision: "accepted",
       recordedAt: "2026-07-19T12:00:00.000Z",
@@ -1242,6 +1385,7 @@ describe("runPipeline", () => {
     });
     const store = new ArtifactStore(runId);
     await expect(store.readResult(runId)).resolves.toEqual(result.attempt);
+    await expectRefMissing(repo, `refs/claude-architect/candidates/${runId}`);
     await expect(readFile(
       path.join(store.runDirectory, "pipeline-active.json"),
       "utf8",
@@ -1312,6 +1456,7 @@ describe("runPipeline", () => {
       },
     });
     await expect(new ArtifactStore(runId).readResult(runId)).resolves.toEqual(result.attempt);
+    await expectRefMissing(repo, `refs/claude-architect/candidates/${runId}`);
   }, { timeout: 120_000 });
 
   it("archives a composed-review failure as the returned non-integrable attempt", async () => {
@@ -1466,6 +1611,7 @@ describe("runPipeline", () => {
       },
     });
     await expect(new ArtifactStore(runId).readResult(runId)).resolves.toEqual(result.attempt);
+    await expectRefMissing(repo, `refs/claude-architect/candidates/${runId}`);
   }, { timeout: 120_000 });
 
   it("runs a completed increment, redacts and archives it, then reviews its diff", async () => {

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -1720,6 +1720,77 @@ describe("runPipeline", () => {
     });
   }, { timeout: 120_000 });
 
+  it("hands a later-slice halt to the human as an acceptable partial candidate", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-partial-halt";
+    const spec = slicedSpec();
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    let reviewerCalls = 0;
+    const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
+      if (args.role === "implementer") {
+        // Slice two never satisfies its verification, so it exhausts its repair
+        // budget and halts — but only after slice one has already advanced.
+        const candidateCommit = await commitRoleFile(
+          args,
+          "slice-two.txt",
+          "wrong slice two\n",
+        );
+        return success(fenced({
+          reportVersion: "1",
+          candidateCommit,
+          status: "complete",
+          summary: "Producer claim is not objective evidence.",
+        }));
+      }
+      reviewerCalls += 1;
+      return success(fenced(approve));
+    };
+    const deps = dependencies({ runId, roleRunner });
+    deps.runAttempt = initialRun;
+    const baselineCommit = await runGit(repo, ["rev-parse", "HEAD"]);
+
+    const result = await runPipeline(repo, spec, deps);
+
+    // A halt after at least one advance is handed to the human, not reported
+    // failed: the design routes it to human-decision-required with the partial
+    // branch promoted for a decision.
+    expect(result).toMatchObject({
+      status: "human-decision-required",
+      haltedSliceIndex: 2,
+      failure: null,
+      increments: [],
+      rounds: [],
+    });
+    expect(result.slices.map(slice => slice.route)).toEqual(["advance", "halt"]);
+    expect(result.slices[1]?.attempts).toHaveLength(2);
+    expect(reviewerCalls).toBe(0);
+    expect(result.gate).toMatchObject({ decisionReady: false, requiresHumanDecision: true });
+    expect(result.finalCandidateCommit).not.toBe(baselineCommit);
+
+    // The partial branch keeps slice one's advance and leaves slice two at its
+    // baseline; the composed verification honestly fails on the unbuilt slice.
+    expect(await runGit(repo, ["show", `${result.finalCandidateCommit}:slice-one.txt`]))
+      .toBe("slice one candidate");
+    expect(await runGit(repo, ["show", `${result.finalCandidateCommit}:slice-two.txt`]))
+      .toBe("slice two base");
+    expect(result.verification?.pass).toBe(false);
+
+    // The promoted partial is a real verified-candidate anchored at the partial
+    // branch, so the human can accept it — the crux of a human-decision halt.
+    const store = new ArtifactStore(runId);
+    await expect(store.readResult(runId)).resolves.toMatchObject({
+      status: "verified-candidate",
+      failure: null,
+      candidate: { candidateCommitOid: result.finalCandidateCommit },
+    });
+    expect(await runGit(repo, ["rev-parse", result.attempt.candidate!.anchorRef]))
+      .toBe(result.finalCandidateCommit);
+    await expect(handleDecideCandidate(repo, runId, "accepted"))
+      .resolves.toEqual({ recorded: true });
+  }, { timeout: 120_000 });
+
   it("archives a SliceExecutionError as the returned non-integrable attempt", async () => {
     const repo = await initSlicedRepo();
     const runId = "pipeline-slices-role-failure";

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -2030,6 +2030,16 @@ describe("runPipeline", () => {
     });
     expect(delegatePipelineOutput.parse({ ok: true, result: { ...result, increments: [] } }))
       .toMatchObject({ result: { increments: [] } });
+    // The wire schema must carry the sliced-pipeline fields through, not strip them.
+    const parsed = delegatePipelineOutput.parse({ ok: true, result });
+    expect(parsed.result).toHaveProperty("slices", []);
+    expect(parsed.result).toHaveProperty("haltedSliceIndex", null);
+    const sliced = delegatePipelineOutput.parse({
+      ok: true,
+      result: { ...result, slices: [{ index: 1, route: "advance" }], haltedSliceIndex: 2 },
+    });
+    expect(sliced.result?.slices).toEqual([{ index: 1, route: "advance" }]);
+    expect(sliced.result?.haltedSliceIndex).toBe(2);
   }, { timeout: 120_000 });
 
   it("exhausts the increment budget after continued real progress and still reviews", async () => {

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -53,7 +53,6 @@ import { buildRunManifest } from "../../src/runtime/run-manifest.js";
 import type {
   AcceptanceVerifierLike,
   AttemptRuntimeDependencies,
-  BorrowedCheckoutLease,
 } from "../../src/runtime/attempt-runtime.js";
 import {
   clearRegisteredSecrets,
@@ -271,14 +270,12 @@ async function checkoutLeaseHarness(
   } = {},
 ): Promise<{
   ps: PlatformServices;
-  expectedRepositoryIdentity: string;
   lock(): CheckoutLock;
   held(): boolean;
   acquireCalls(): number;
   releaseCalls(): number;
 }> {
   const platformServices = getPlatformServices();
-  const canonical = await platformServices.canonicalizePath(repo);
   let lock: CheckoutLock | undefined;
   let held = false;
   let acquireCalls = 0;
@@ -290,6 +287,7 @@ async function checkoutLeaseHarness(
       held = true;
       lock = {
         key: ownedLock.key,
+        repositoryIdentity: ownedLock.repositoryIdentity,
         async release() {
           releaseCalls += 1;
           try {
@@ -306,7 +304,6 @@ async function checkoutLeaseHarness(
   }) as PlatformServices;
   return {
     ps,
-    expectedRepositoryIdentity: canonical.gitCommonDir ?? canonical.canonical,
     lock: () => {
       if (lock === undefined) throw new Error("checkout lock was not acquired");
       return lock;
@@ -786,6 +783,55 @@ describe("pipeline runtime namespaces", () => {
 });
 
 describe("runPipeline", () => {
+  it("passes the acquisition-bound identity when canonicalization changes before lock acquisition", async () => {
+    const repo = await initRepo();
+    const platformServices = getPlatformServices();
+    const canonical = await platformServices.canonicalizePath(repo);
+    const preAcquireIdentity = `${canonical.gitCommonDir ?? canonical.canonical}-before-acquire`;
+    const acquisitionIdentity = `${canonical.gitCommonDir ?? canonical.canonical}-at-acquire`;
+    const observations: string[] = [];
+    let acquiredLock: CheckoutLock | undefined;
+    let releaseCalls = 0;
+    let ps: PlatformServices;
+    ps = Object.assign(Object.create(platformServices), {
+      async canonicalizePath(input: string) {
+        const repositoryIdentity = observations.length === 0
+          ? preAcquireIdentity
+          : acquisitionIdentity;
+        observations.push(repositoryIdentity);
+        return { input, canonical: canonical.canonical, gitCommonDir: repositoryIdentity };
+      },
+      async acquireCheckoutLock(checkout: string) {
+        const acquired = await ps.canonicalizePath(checkout);
+        const repositoryIdentity = acquired.gitCommonDir ?? acquired.canonical;
+        acquiredLock = {
+          key: createHash("sha256").update(repositoryIdentity).digest("hex"),
+          repositoryIdentity,
+          async release() { releaseCalls += 1; },
+        };
+        return acquiredLock;
+      },
+    }) as PlatformServices;
+    let receivedLease: AttemptRuntimeDependencies["borrowedCheckoutLease"];
+
+    const result = await runPipeline(repo, validSpec(), {
+      verifier: passingVerifier,
+      ps,
+      registry: new ProducerRegistry([]),
+      roleRunner: async () => { throw new Error("role runner must not run"); },
+      runAttempt: async (_checkoutPath, _spec, attemptDeps) => {
+        receivedLease = attemptDeps.borrowedCheckoutLease;
+        return failedAttemptResult("pipeline-acquisition-bound-identity");
+      },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(observations).toEqual([preAcquireIdentity, acquisitionIdentity]);
+    expect(receivedLease).toBe(acquiredLock);
+    expect(receivedLease?.repositoryIdentity).toBe(acquisitionIdentity);
+    expect(releaseCalls).toBe(1);
+  });
+
   it("holds one checkout lease through attempt, review, fix, verification, and marker cleanup", async () => {
     const repo = await initRepo();
     const runId = "pipeline-continuous-checkout-lease";
@@ -836,7 +882,7 @@ describe("runPipeline", () => {
     const deps = dependencies({ runId, roleRunner });
     deps.ps = lease.ps;
     const initialRun = deps.runAttempt!;
-    let receivedLease: BorrowedCheckoutLease | undefined;
+    let receivedLease: CheckoutLock | undefined;
     deps.runAttempt = async (checkoutPath, receivedSpec, attemptDeps) => {
       expect(lease.held()).toBe(true);
       receivedLease = attemptDeps.borrowedCheckoutLease;
@@ -859,10 +905,7 @@ describe("runPipeline", () => {
 
     expect(result.status).toBe("decision-ready");
     expect(result.increments).toHaveLength(1);
-    expect(receivedLease).toEqual({
-      lock: lease.lock(),
-      repositoryIdentity: lease.expectedRepositoryIdentity,
-    });
+    expect(receivedLease).toBe(lease.lock());
     expect(verifySpy).toHaveBeenCalled();
     expect(clearMarkerSpy).toHaveBeenCalledOnce();
     expect(lease.acquireCalls()).toBe(1);
@@ -922,7 +965,7 @@ describe("runPipeline", () => {
     });
     deps.ps = lease.ps;
     const initialRun = deps.runAttempt!;
-    let receivedLease: BorrowedCheckoutLease | undefined;
+    let receivedLease: CheckoutLock | undefined;
     deps.runAttempt = async (checkoutPath, receivedSpec, attemptDeps) => {
       expect(lease.held()).toBe(true);
       receivedLease = attemptDeps.borrowedCheckoutLease;
@@ -937,10 +980,7 @@ describe("runPipeline", () => {
     const result = await runPipeline(repo, slicedSpec(), deps);
 
     expect(result.status).toBe("decision-ready");
-    expect(receivedLease).toEqual({
-      lock: lease.lock(),
-      repositoryIdentity: lease.expectedRepositoryIdentity,
-    });
+    expect(receivedLease).toBe(lease.lock());
     expect(lease.acquireCalls()).toBe(1);
     expect(lease.releaseCalls()).toBe(1);
     expect(lease.held()).toBe(false);
@@ -951,7 +991,7 @@ describe("runPipeline", () => {
     const repo = await initRepo();
     const lease = await checkoutLeaseHarness(repo);
     const failing = failedAttemptResult("pipeline-attempt-lock-release");
-    let receivedLease: BorrowedCheckoutLease | undefined;
+    let receivedLease: CheckoutLock | undefined;
 
     const result = await runPipeline(repo, validSpec(), {
       verifier: passingVerifier,
@@ -966,7 +1006,7 @@ describe("runPipeline", () => {
     });
 
     expect(result.status).toBe("failed");
-    expect(receivedLease?.lock).toBe(lease.lock());
+    expect(receivedLease).toBe(lease.lock());
     expect(lease.acquireCalls()).toBe(1);
     expect(lease.releaseCalls()).toBe(1);
     expect(lease.held()).toBe(false);

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -347,6 +347,98 @@ async function commitIncrement(
   return runGit(args.worktreePath, ["rev-parse", "HEAD"], env);
 }
 
+async function initSlicedRepo(): Promise<string> {
+  const repo = await initRepo();
+  await writeFile(path.join(repo, "slice-one.txt"), "slice one base\n");
+  await writeFile(path.join(repo, "slice-two.txt"), "slice two base\n");
+  await runGit(repo, ["add", "slice-one.txt", "slice-two.txt"]);
+  await runGit(repo, ["commit", "-q", "-m", "slice fixtures"]);
+  return repo;
+}
+
+function fileVerification(
+  id: string,
+  expected: Record<string, string>,
+): Slice["verification"][number] {
+  return {
+    id,
+    executable: "node",
+    args: [
+      "-e",
+      [
+        "const fs = require('node:fs');",
+        `const expected = ${JSON.stringify(expected)};`,
+        "for (const [name, content] of Object.entries(expected)) {",
+        "  if (fs.readFileSync(name, 'utf8') !== content) process.exit(1);",
+        "}",
+        "process.stdout.write(process.cwd());",
+      ].join(" "),
+    ],
+    cwd: ".",
+    timeoutMs: 60_000,
+    network: "denied",
+    expectedExitCodes: [0],
+  };
+}
+
+function slicedSpec(perSlice = false): DelegationSpec {
+  const slices: Slice[] = [{
+    objective: "Implement slice one only.",
+    context: "slice-one.txt is the only writable path.",
+    writeAllowlist: ["slice-one.txt"],
+    forbiddenScope: [],
+    successCriteria: ["slice-one.txt contains the slice-one candidate."],
+    verification: [fileVerification("slice-one-check", {
+      "slice-one.txt": "slice one candidate\n",
+    })],
+  }, {
+    objective: "Implement slice two only.",
+    context: "Preserve slice one and update only slice-two.txt.",
+    writeAllowlist: ["slice-two.txt"],
+    forbiddenScope: [],
+    successCriteria: ["slice-two.txt contains the slice-two candidate."],
+    verification: [fileVerification("slice-two-check", {
+      "slice-one.txt": "slice one candidate\n",
+      "slice-two.txt": "slice two candidate\n",
+    })],
+  }];
+  return {
+    ...validSpec({
+      reviewers: ["correctness"],
+      maxRounds: 1,
+      ...(perSlice ? { perSlice: true } : {}),
+    }),
+    objective: "Implement both ordered slices.",
+    context: "Each slice has a disjoint write allowlist.",
+    writeAllowlist: ["slice-one.txt", "slice-two.txt"],
+    successCriteria: ["Both slice files contain their candidate content."],
+    verification: [fileVerification("final-check", {
+      "slice-one.txt": "slice one candidate\n",
+      "slice-two.txt": "slice two candidate\n",
+    })],
+    implementation: { maxIncrements: 2 },
+    slices,
+  };
+}
+
+async function commitRoleFile(
+  args: RoleRunArgs,
+  pathname: string,
+  content: string,
+): Promise<string> {
+  if (args.gitObjectAccess === undefined) {
+    throw new Error("implementer git object isolation is missing");
+  }
+  const env = {
+    GIT_OBJECT_DIRECTORY: args.gitObjectAccess.privateObjectsDir,
+    GIT_ALTERNATE_OBJECT_DIRECTORIES: args.gitObjectAccess.sharedObjectsDir,
+  };
+  await writeFile(path.join(args.worktreePath, pathname), content);
+  await runGit(args.worktreePath, ["add", pathname], env);
+  await runGit(args.worktreePath, ["commit", "-q", "-m", `update ${pathname}`], env);
+  return runGit(args.worktreePath, ["rev-parse", "HEAD"], env);
+}
+
 beforeEach(async () => {
   previousPluginData = process.env.CLAUDE_PLUGIN_DATA;
   previousNodeEnvironment = process.env.NODE_ENV;
@@ -571,6 +663,274 @@ describe("pipeline runtime namespaces", () => {
 });
 
 describe("runPipeline", () => {
+  it("advances disjoint slices through private provenance and composed gates", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-advance";
+    const spec = slicedSpec();
+    const parentSnapshot = structuredClone(spec);
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    let initialSpec: DelegationSpec | undefined;
+    let implementerArgs: RoleRunArgs | undefined;
+    const reviewArgs: RoleRunArgs[] = [];
+    const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
+      if (args.role === "implementer") {
+        implementerArgs = args;
+        expect(await readFile(path.join(args.worktreePath, "slice-one.txt"), "utf8"))
+          .toBe("slice one candidate\n");
+        const candidateCommit = await commitRoleFile(
+          args,
+          "slice-two.txt",
+          "slice two candidate\n",
+        );
+        return success(fenced({
+          reportVersion: "1",
+          candidateCommit,
+          status: "blocked",
+          summary: "Producer status must not control objective routing.",
+          blockers: "Untrusted Producer claim.",
+        }));
+      }
+      if (args.role === "reviewer-correctness") {
+        reviewArgs.push(args);
+        return success(fenced(approve));
+      }
+      throw new Error(`unexpected role ${args.role}`);
+    };
+    const deps = dependencies({ runId, roleRunner });
+    deps.runAttempt = async (checkoutPath, receivedSpec) => {
+      initialSpec = structuredClone(receivedSpec);
+      return initialRun(checkoutPath);
+    };
+    const acceptanceSpy = vi.spyOn(AcceptanceVerifier.prototype, "verify");
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(initialSpec).toEqual(scopeSpecToSlice(parentSnapshot, parentSnapshot.slices![0]!));
+    expect(initialSpec).not.toHaveProperty("slices");
+    expect(spec).toEqual(parentSnapshot);
+    expect(implementerArgs?.baseSpec).toEqual(
+      scopeSpecToSlice(parentSnapshot, parentSnapshot.slices![1]!),
+    );
+    expect(implementerArgs?.pkg.spec).toEqual(implementerArgs?.baseSpec);
+    expect(implementerArgs?.pkg.baselineCommit).toBe(result.slices[0]?.candidateCommit);
+    expect(implementerArgs?.pkg.candidateCommit).toBe(result.slices[0]?.candidateCommit);
+    expect(implementerArgs?.pkg.candidateDiff).toBe("");
+    expect(implementerArgs?.pkg).not.toHaveProperty("progress");
+    expect(path.basename(implementerArgs?.worktreePath ?? "")).toBe(
+      `${runId}-slice-2-attempt-0`,
+    );
+
+    expect(reviewArgs).toHaveLength(1);
+    expect(reviewArgs[0]?.baseSpec).toEqual(parentSnapshot);
+    expect(reviewArgs[0]?.pkg.candidateDiff).toContain("slice one candidate");
+    expect(reviewArgs[0]?.pkg.candidateDiff).toContain("slice two candidate");
+    expect(reviewArgs[0]?.pkg.testEvidence).toContain('"sliceIndex":1');
+    expect(reviewArgs[0]?.pkg.testEvidence).toContain('"sliceIndex":2');
+    expect(path.basename(reviewArgs[0]?.worktreePath ?? "")).toBe(`${runId}-composed-review`);
+
+    expect(result).toMatchObject({
+      status: "decision-ready",
+      increments: [],
+      haltedSliceIndex: null,
+      failure: null,
+    });
+    expect(result.slices).toHaveLength(2);
+    expect(result.slices.map(slice => slice.route)).toEqual(["advance", "advance"]);
+    expect(result.slices[0]?.roleLogRefs).toEqual(["logs/producer.log"]);
+    expect(result.slices[1]?.roleLogRefs).toEqual([
+      "logs/role-implementer-slice-2-attempt-0-increment1.log",
+    ]);
+    expect(result.slices[1]?.verification?.scopeViolations).toEqual([]);
+    expect(result.rounds).toHaveLength(1);
+    expect(result.verification?.pass).toBe(true);
+
+    expect(acceptanceSpy.mock.calls.map(call => path.basename(call[0].worktreePath))).toEqual([
+      `${runId}-slice-1-attempt-0-verify`,
+      `${runId}-slice-2-attempt-0-verify`,
+      `${runId}-final-verify`,
+    ]);
+    const verificationIds = acceptanceSpy.mock.calls.map(call => call[0].verificationId?.());
+    expect(verificationIds).toEqual([
+      `${runId}-slice-1-attempt-0-pipeline`,
+      `${runId}-slice-2-attempt-0-pipeline`,
+      `${runId}-final-pipeline`,
+    ]);
+    const store = new ArtifactStore(runId);
+    const sliceOneStdout = result.slices[0]?.verification?.evidence.commandOutcomes[0]?.stdoutRef;
+    const sliceTwoStdout = result.slices[1]?.verification?.evidence.commandOutcomes[0]?.stdoutRef;
+    const finalStdout = result.verification?.evidence.commandOutcomes[0]?.stdoutRef;
+    expect([sliceOneStdout, sliceTwoStdout, finalStdout]).toEqual([
+      "logs/slice-1-attempt-0-pipeline-verification-0-stdout.log",
+      "logs/slice-2-attempt-0-pipeline-verification-0-stdout.log",
+      "logs/final-pipeline-verification-0-stdout.log",
+    ]);
+    const nestedWorktrees = await Promise.all(
+      [sliceOneStdout, sliceTwoStdout, finalStdout].map(async ref =>
+        path.basename(await readFile(path.join(store.runDirectory, ref!), "utf8"))),
+    );
+    expect(nestedWorktrees).toEqual([
+      `verify-${runId}-slice-1-attempt-0-pipeline`,
+      `verify-${runId}-slice-2-attempt-0-pipeline`,
+      `verify-${runId}-final-pipeline`,
+    ]);
+    expect(new Set([
+      implementerArgs?.worktreePath,
+      reviewArgs[0]?.worktreePath,
+      ...acceptanceSpy.mock.calls.map(call => call[0].worktreePath),
+      ...nestedWorktrees,
+    ]).size).toBe(8);
+
+    await expect(store.readPipelineArtifact(runId, "slice-1-attempt-0"))
+      .resolves.toMatchObject({ sliceIndex: 1, attempt: 0, route: "advance" });
+    await expect(store.readPipelineArtifact(runId, "slice-1"))
+      .resolves.toMatchObject({ index: 1, route: "advance" });
+    await expect(store.readPipelineArtifact(runId, "slice-2-attempt-0"))
+      .resolves.toMatchObject({ sliceIndex: 2, attempt: 0, route: "advance" });
+    await expect(store.readPipelineArtifact(runId, "slice-2"))
+      .resolves.toMatchObject({ index: 2, route: "advance" });
+    expect(result.attempt.candidate?.candidateCommitOid).toBe(result.finalCandidateCommit);
+    await expect(store.readResult(runId)).resolves.toMatchObject({
+      candidate: { candidateCommitOid: result.finalCandidateCommit },
+    });
+    expect(await runGit(repo, ["rev-parse", result.attempt.candidate!.anchorRef]))
+      .toBe(result.finalCandidateCommit);
+    expect(await runGit(repo, ["show", `${result.finalCandidateCommit}:slice-one.txt`]))
+      .toBe("slice one candidate");
+    expect(await runGit(repo, ["show", `${result.finalCandidateCommit}:slice-two.txt`]))
+      .toBe("slice two candidate");
+  }, { timeout: 120_000 });
+
+  it("runs independent per-slice reviewers with slice-local evidence and logs", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-review";
+    const spec = slicedSpec(true);
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+    });
+    const reviewerArgs: RoleRunArgs[] = [];
+    const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
+      if (args.role === "implementer") {
+        const candidateCommit = await commitRoleFile(
+          args,
+          "slice-two.txt",
+          "slice two candidate\n",
+        );
+        return success(fenced({
+          reportVersion: "1",
+          candidateCommit,
+          status: "continue",
+          summary: "Producer continuation is non-authoritative.",
+          nextSteps: "Objective gates decide advancement.",
+        }));
+      }
+      if (args.role === "reviewer-correctness") {
+        reviewerArgs.push(args);
+        return success(fenced(approve));
+      }
+      throw new Error(`unexpected role ${args.role}`);
+    };
+    const deps = dependencies({ runId, roleRunner });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(result.status).toBe("decision-ready");
+    expect(result.slices).toHaveLength(2);
+    expect(reviewerArgs).toHaveLength(3);
+    expect(reviewerArgs.map(args => path.basename(args.worktreePath))).toEqual([
+      `${runId}-slice-1-attempt-0-review`,
+      `${runId}-slice-2-attempt-0-review`,
+      `${runId}-composed-review`,
+    ]);
+    expect(reviewerArgs[0]?.baseSpec.objective).toBe("Implement slice one only.");
+    expect(reviewerArgs[0]?.pkg.candidateDiff).toContain("slice one candidate");
+    expect(reviewerArgs[0]?.pkg.candidateDiff).not.toContain("slice two candidate");
+    expect(reviewerArgs[0]?.pkg.testEvidence).toContain('"slice-one-check"');
+    expect(reviewerArgs[1]?.baseSpec.objective).toBe("Implement slice two only.");
+    expect(reviewerArgs[1]?.pkg.candidateDiff).toContain("slice two candidate");
+    expect(reviewerArgs[1]?.pkg.candidateDiff).not.toContain("slice one candidate");
+    expect(reviewerArgs[1]?.pkg.testEvidence).toContain('"slice-two-check"');
+    expect(reviewerArgs[2]?.baseSpec.objective).toBe("Implement both ordered slices.");
+    expect(reviewerArgs[2]?.pkg.testEvidence).toContain('"sliceIndex":1');
+    expect(reviewerArgs[2]?.pkg.testEvidence).toContain('"sliceIndex":2');
+    expect(result.slices.map(slice => slice.perSliceReview)).toEqual([
+      { findings: [], contradictions: [] },
+      { findings: [], contradictions: [] },
+    ]);
+    expect(result.slices.map(slice => slice.roleLogRefs)).toEqual([
+      [
+        "logs/producer.log",
+        "logs/role-reviewer-correctness-slice-1-attempt-0-round1.log",
+      ],
+      [
+        "logs/role-implementer-slice-2-attempt-0-increment1.log",
+        "logs/role-reviewer-correctness-slice-2-attempt-0-round1.log",
+      ],
+    ]);
+  }, { timeout: 120_000 });
+
+  it("returns an explicit failed sliced result when objective routing halts", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-slices-halt";
+    const spec = slicedSpec();
+    spec.writeAllowlist.push("a.txt");
+    const initialRun = fakeAttempt(runId, async checkout => {
+      await writeFile(path.join(checkout, "a.txt"), "out of slice one scope\n");
+    });
+    let reviewerCalls = 0;
+    const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
+      if (args.role === "implementer") {
+        const candidateCommit = await commitRoleFile(
+          args,
+          "a.txt",
+          "still out of slice one scope\n",
+        );
+        return success(fenced({
+          reportVersion: "1",
+          candidateCommit,
+          status: "complete",
+          summary: "Untrusted repair remained outside the slice.",
+        }));
+      }
+      reviewerCalls += 1;
+      return success(fenced(approve));
+    };
+    const deps = dependencies({ runId, roleRunner });
+    deps.runAttempt = async checkoutPath => initialRun(checkoutPath);
+    const baselineCommit = await runGit(repo, ["rev-parse", "HEAD"]);
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(result).toMatchObject({
+      status: "failed",
+      increments: [],
+      haltedSliceIndex: 1,
+      rounds: [],
+      verification: null,
+      finalCandidateCommit: baselineCommit,
+      failure: "verification-failure",
+    });
+    expect(result.slices).toHaveLength(1);
+    expect(result.slices[0]).toMatchObject({
+      index: 1,
+      route: "halt",
+      roundsUsed: 1,
+      reasons: ["slice verification failed", "out-of-scope diff: a.txt"],
+    });
+    expect(result.slices[0]?.attempts).toHaveLength(2);
+    expect(reviewerCalls).toBe(0);
+    expect(result.attempt.candidate?.candidateCommitOid).not.toBe(result.finalCandidateCommit);
+    const store = new ArtifactStore(runId);
+    await expect(store.readPipelineArtifact(runId, "slice-1-attempt-0"))
+      .resolves.toMatchObject({ route: "repair" });
+    await expect(store.readPipelineArtifact(runId, "slice-1-attempt-1"))
+      .resolves.toMatchObject({ route: "halt" });
+    await expect(store.readPipelineArtifact(runId, "slice-1"))
+      .resolves.toMatchObject({ route: "halt" });
+  }, { timeout: 120_000 });
+
   it("runs a completed increment, redacts and archives it, then reviews its diff", async () => {
     const repo = await initRepo();
     registerSecretValue("increment-secret-value");

--- a/tests/runtime/pipeline-runtime.test.ts
+++ b/tests/runtime/pipeline-runtime.test.ts
@@ -19,6 +19,10 @@ import {
   handleDecideCandidate,
   handleIntegrateCandidate,
 } from "../../src/mcp/tools.js";
+import type {
+  CheckoutLock,
+  PlatformServices,
+} from "../../src/platform/platform-services.js";
 import { getPlatformServices } from "../../src/platform/select-platform.js";
 import type {
   AttemptResult,
@@ -49,6 +53,7 @@ import { buildRunManifest } from "../../src/runtime/run-manifest.js";
 import type {
   AcceptanceVerifierLike,
   AttemptRuntimeDependencies,
+  BorrowedCheckoutLease,
 } from "../../src/runtime/attempt-runtime.js";
 import {
   clearRegisteredSecrets,
@@ -233,6 +238,82 @@ function attemptResult(runId: string, candidate: CandidateArtifact): AttemptResu
     producerModel: null,
     durationMs: 1,
     sessionId: null,
+  };
+}
+
+function failedAttemptResult(runId: string): AttemptResult {
+  return {
+    resultVersion: "1",
+    runId,
+    status: "failed",
+    failure: "verification-failure",
+    summary: "candidate did not pass independent verification",
+    producerSummary: "test producer",
+    candidate: null,
+    requestedVerification: [],
+    executedVerification: [],
+    unresolvedIssues: ["base-changed"],
+    evidence: { structural: { failures: ["base-changed"] } },
+    logsRef: "logs/producer.log",
+    producerId: "stub",
+    producerVersion: "1",
+    producerModel: null,
+    durationMs: 1,
+    sessionId: null,
+  };
+}
+
+async function checkoutLeaseHarness(
+  repo: string,
+  options: {
+    releaseError?: Error;
+    onRelease?: () => void | Promise<void>;
+  } = {},
+): Promise<{
+  ps: PlatformServices;
+  expectedRepositoryIdentity: string;
+  lock(): CheckoutLock;
+  held(): boolean;
+  acquireCalls(): number;
+  releaseCalls(): number;
+}> {
+  const platformServices = getPlatformServices();
+  const canonical = await platformServices.canonicalizePath(repo);
+  let lock: CheckoutLock | undefined;
+  let held = false;
+  let acquireCalls = 0;
+  let releaseCalls = 0;
+  const ps = Object.assign(Object.create(platformServices), {
+    async acquireCheckoutLock(checkout: string): Promise<CheckoutLock> {
+      acquireCalls += 1;
+      const ownedLock = await platformServices.acquireCheckoutLock(checkout);
+      held = true;
+      lock = {
+        key: ownedLock.key,
+        async release() {
+          releaseCalls += 1;
+          try {
+            await options.onRelease?.();
+            if (options.releaseError !== undefined) throw options.releaseError;
+          } finally {
+            await ownedLock.release();
+            held = false;
+          }
+        },
+      };
+      return lock;
+    },
+  }) as PlatformServices;
+  return {
+    ps,
+    expectedRepositoryIdentity: canonical.gitCommonDir ?? canonical.canonical,
+    lock: () => {
+      if (lock === undefined) throw new Error("checkout lock was not acquired");
+      return lock;
+    },
+    held: () => held,
+    acquireCalls: () => acquireCalls,
+    releaseCalls: () => releaseCalls,
   };
 }
 
@@ -705,6 +786,256 @@ describe("pipeline runtime namespaces", () => {
 });
 
 describe("runPipeline", () => {
+  it("holds one checkout lease through attempt, review, fix, verification, and marker cleanup", async () => {
+    const repo = await initRepo();
+    const runId = "pipeline-continuous-checkout-lease";
+    const spec = validSpec();
+    spec.implementation = { maxIncrements: 2 };
+    const store = new ArtifactStore(runId);
+    let releaseObservedLast = false;
+    let lease: Awaited<ReturnType<typeof checkoutLeaseHarness>>;
+    lease = await checkoutLeaseHarness(repo, {
+      onRelease: async () => {
+        expect(lease.held()).toBe(true);
+        await expect(store.readPipelineActiveMarker(runId)).resolves.toBeNull();
+        await expect(store.readPipelineArtifact(runId, "pipeline-result"))
+          .resolves.toMatchObject({ status: "decision-ready" });
+        releaseObservedLast = true;
+      },
+    });
+    const baseRoleRunner = roundReviews([
+      { correctness: blocker, systems: approve },
+      { correctness: approve, systems: approve },
+    ], async args => {
+      expect(lease.held()).toBe(true);
+      const commit = await commitFix(args, "lease-protected fix\n");
+      return success(fenced({
+        reportVersion: "1",
+        candidateCommit: commit,
+        dispositions: [{
+          findingId: "F-001",
+          disposition: "fixed",
+          evidence: "Committed under the pipeline lease.",
+          commit,
+        }],
+      }));
+    });
+    const roleRunner = async (args: RoleRunArgs): Promise<RoleRunResult> => {
+      expect(lease.held()).toBe(true);
+      if (args.role === "implementer") {
+        const candidateCommit = await commitIncrement(args, "lease-protected increment\n");
+        return success(fenced({
+          reportVersion: "1",
+          candidateCommit,
+          status: "complete",
+          summary: "increment complete",
+        }));
+      }
+      return baseRoleRunner(args);
+    };
+    const deps = dependencies({ runId, roleRunner });
+    deps.ps = lease.ps;
+    const initialRun = deps.runAttempt!;
+    let receivedLease: BorrowedCheckoutLease | undefined;
+    deps.runAttempt = async (checkoutPath, receivedSpec, attemptDeps) => {
+      expect(lease.held()).toBe(true);
+      receivedLease = attemptDeps.borrowedCheckoutLease;
+      return initialRun(checkoutPath, receivedSpec, attemptDeps);
+    };
+    const verify = AcceptanceVerifier.prototype.verify;
+    const verifySpy = vi.spyOn(AcceptanceVerifier.prototype, "verify")
+      .mockImplementation(function (args) {
+        expect(lease.held()).toBe(true);
+        return verify.call(this, args);
+      });
+    const clearMarker = ArtifactStore.prototype.clearPipelineActiveMarker;
+    const clearMarkerSpy = vi.spyOn(ArtifactStore.prototype, "clearPipelineActiveMarker")
+      .mockImplementation(function () {
+        expect(lease.held()).toBe(true);
+        return clearMarker.call(this);
+      });
+
+    const result = await runPipeline(repo, spec, deps);
+
+    expect(result.status).toBe("decision-ready");
+    expect(result.increments).toHaveLength(1);
+    expect(receivedLease).toEqual({
+      lock: lease.lock(),
+      repositoryIdentity: lease.expectedRepositoryIdentity,
+    });
+    expect(verifySpy).toHaveBeenCalled();
+    expect(clearMarkerSpy).toHaveBeenCalledOnce();
+    expect(lease.acquireCalls()).toBe(1);
+    expect(lease.releaseCalls()).toBe(1);
+    expect(lease.held()).toBe(false);
+    expect(releaseObservedLast).toBe(true);
+  }, { timeout: 120_000 });
+
+  it("holds the borrowed lease through the early sliced marker and temporary-ref cleanup", async () => {
+    const repo = await initSlicedRepo();
+    const runId = "pipeline-sliced-continuous-checkout-lease";
+    const store = new ArtifactStore(runId);
+    const temporaryRef = `refs/claude-architect/slices/${runId}/slice-2-attempt-0`;
+    let releaseObservedLast = false;
+    let lease: Awaited<ReturnType<typeof checkoutLeaseHarness>>;
+    lease = await checkoutLeaseHarness(repo, {
+      onRelease: async () => {
+        expect(lease.held()).toBe(true);
+        await expectRefMissing(repo, temporaryRef);
+        await expect(store.readPipelineActiveMarker(runId)).resolves.toBeNull();
+        await expect(store.readPipelineArtifact(runId, "pipeline-result"))
+          .resolves.toMatchObject({ status: "decision-ready" });
+        releaseObservedLast = true;
+      },
+    });
+    const deps = dependencies({
+      runId,
+      edit: async checkout => {
+        expect(lease.held()).toBe(true);
+        await expect(store.readPipelineActiveMarker(runId)).resolves.toMatchObject({
+          sliced: true,
+        });
+        await writeFile(path.join(checkout, "slice-one.txt"), "slice one candidate\n");
+      },
+      roleRunner: async args => {
+        expect(lease.held()).toBe(true);
+        if (args.role === "implementer") {
+          const candidateCommit = await commitRoleFile(
+            args,
+            "slice-two.txt",
+            "slice two candidate\n",
+          );
+          return success(fenced({
+            reportVersion: "1",
+            candidateCommit,
+            status: "complete",
+            summary: "slice complete",
+          }));
+        }
+        if (args.role === "reviewer-correctness") {
+          expect(await runGit(repo, ["rev-parse", "--verify", temporaryRef]))
+            .toMatch(/^[0-9a-f]{40}$/);
+          return success(fenced(approve));
+        }
+        throw new Error(`unexpected role ${args.role}`);
+      },
+    });
+    deps.ps = lease.ps;
+    const initialRun = deps.runAttempt!;
+    let receivedLease: BorrowedCheckoutLease | undefined;
+    deps.runAttempt = async (checkoutPath, receivedSpec, attemptDeps) => {
+      expect(lease.held()).toBe(true);
+      receivedLease = attemptDeps.borrowedCheckoutLease;
+      return initialRun(checkoutPath, receivedSpec, attemptDeps);
+    };
+    const verify = AcceptanceVerifier.prototype.verify;
+    vi.spyOn(AcceptanceVerifier.prototype, "verify").mockImplementation(function (args) {
+      expect(lease.held()).toBe(true);
+      return verify.call(this, args);
+    });
+
+    const result = await runPipeline(repo, slicedSpec(), deps);
+
+    expect(result.status).toBe("decision-ready");
+    expect(receivedLease).toEqual({
+      lock: lease.lock(),
+      repositoryIdentity: lease.expectedRepositoryIdentity,
+    });
+    expect(lease.acquireCalls()).toBe(1);
+    expect(lease.releaseCalls()).toBe(1);
+    expect(lease.held()).toBe(false);
+    expect(releaseObservedLast).toBe(true);
+  }, { timeout: 120_000 });
+
+  it("releases the checkout lease after a non-verified initial result", async () => {
+    const repo = await initRepo();
+    const lease = await checkoutLeaseHarness(repo);
+    const failing = failedAttemptResult("pipeline-attempt-lock-release");
+    let receivedLease: BorrowedCheckoutLease | undefined;
+
+    const result = await runPipeline(repo, validSpec(), {
+      verifier: passingVerifier,
+      ps: lease.ps,
+      registry: new ProducerRegistry([]),
+      roleRunner: async () => { throw new Error("role runner must not run"); },
+      runAttempt: async (_checkoutPath, _spec, attemptDeps) => {
+        expect(lease.held()).toBe(true);
+        receivedLease = attemptDeps.borrowedCheckoutLease;
+        return failing;
+      },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(receivedLease?.lock).toBe(lease.lock());
+    expect(lease.acquireCalls()).toBe(1);
+    expect(lease.releaseCalls()).toBe(1);
+    expect(lease.held()).toBe(false);
+  });
+
+  it("releases the checkout lease when the initial attempt throws", async () => {
+    const repo = await initRepo();
+    const lease = await checkoutLeaseHarness(repo);
+
+    await expect(runPipeline(repo, validSpec(), {
+      verifier: passingVerifier,
+      ps: lease.ps,
+      registry: new ProducerRegistry([]),
+      roleRunner: async () => { throw new Error("role runner must not run"); },
+      runAttempt: async () => {
+        expect(lease.held()).toBe(true);
+        throw new Error("initial attempt failed");
+      },
+    })).rejects.toThrow("initial attempt failed");
+
+    expect(lease.acquireCalls()).toBe(1);
+    expect(lease.releaseCalls()).toBe(1);
+    expect(lease.held()).toBe(false);
+  });
+
+  it("reports a checkout lease release failure after an otherwise classified result", async () => {
+    const repo = await initRepo();
+    const releaseError = new Error("checkout lease release failed");
+    const lease = await checkoutLeaseHarness(repo, { releaseError });
+
+    await expect(runPipeline(repo, validSpec(), {
+      verifier: passingVerifier,
+      ps: lease.ps,
+      registry: new ProducerRegistry([]),
+      roleRunner: async () => { throw new Error("role runner must not run"); },
+      runAttempt: async () => failedAttemptResult("pipeline-release-failure"),
+    })).rejects.toBe(releaseError);
+
+    expect(lease.acquireCalls()).toBe(1);
+    expect(lease.releaseCalls()).toBe(1);
+    expect(lease.held()).toBe(false);
+  });
+
+  it("aggregates checkout lease release failure with the primary pipeline error", async () => {
+    const repo = await initRepo();
+    const primaryError = new Error("pipeline primary failure");
+    const releaseError = new Error("checkout lease release failed");
+    const lease = await checkoutLeaseHarness(repo, { releaseError });
+    let thrown: unknown;
+
+    try {
+      await runPipeline(repo, validSpec(), {
+        verifier: passingVerifier,
+        ps: lease.ps,
+        registry: new ProducerRegistry([]),
+        roleRunner: async () => { throw new Error("role runner must not run"); },
+        runAttempt: async () => { throw primaryError; },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect((thrown as AggregateError).errors).toEqual([primaryError, releaseError]);
+    expect(lease.acquireCalls()).toBe(1);
+    expect(lease.releaseCalls()).toBe(1);
+    expect(lease.held()).toBe(false);
+  });
+
   it("establishes sliced lifecycle authority before the initial candidate is created", async () => {
     const repo = await initSlicedRepo();
     const runId = "pipeline-slices-early-marker";

--- a/tests/runtime/pipeline/slice-runner.test.ts
+++ b/tests/runtime/pipeline/slice-runner.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import type { ConsolidationResult } from '../../../src/pipeline/consolidator.js';
 import type { VerificationReport } from '../../../src/pipeline/report-types.js';
-import { runSlicePhase, type SliceAttempt } from '../../../src/pipeline/slice-runner.js';
+import {
+  runSlicePhase,
+  type SliceAttempt,
+  type SliceAttemptEvidence,
+} from '../../../src/pipeline/slice-runner.js';
 import type { Slice } from '../../../src/protocol/delegation-spec.js';
 
 function slice(objective: string): Slice {
@@ -33,6 +38,23 @@ function attempt(candidateCommit: string, pass: boolean, hardBlocker = false): S
   };
 }
 
+function review(severity: 'blocker' | 'major' | 'minor'): ConsolidationResult {
+  return {
+    findings: [{
+      id: 'F-001',
+      severity,
+      location: 'src/example.ts:1',
+      claim: 'objective finding',
+      evidence: 'review evidence',
+      reproduction: 'inspect the candidate',
+      requiredOutcome: 'correct the candidate',
+      confidence: 1,
+      reviewers: ['correctness'],
+    }],
+    contradictions: [],
+  };
+}
+
 describe('runSlicePhase', () => {
   it('advances through all green slices', async () => {
     const runSlice = vi
@@ -56,6 +78,129 @@ describe('runSlicePhase', () => {
     expect(runSlice).toHaveBeenNthCalledWith(1, expect.anything(), 1, 'start', 0);
     expect(runSlice).toHaveBeenNthCalledWith(2, expect.anything(), 2, 'slice-1-commit', 0);
   });
+
+  it('consumes a green initial attempt before running slice 2 from its commit', async () => {
+    const slices = [slice('seeded'), slice('second')];
+    const runSlice = vi.fn().mockResolvedValue(attempt('slice-2-commit', true));
+
+    const result = await runSlicePhase(slices, 'start', {
+      runSlice,
+      maxRounds: 1,
+      initialAttempt: attempt('seed-commit', true),
+    });
+
+    expect(runSlice).toHaveBeenCalledTimes(1);
+    expect(runSlice).toHaveBeenCalledWith(slices[1], 2, 'seed-commit', 0);
+    expect(result.slices.map(({ index, candidateCommit }) => ({ index, candidateCommit }))).toEqual([
+      { index: 1, candidateCommit: 'seed-commit' },
+      { index: 2, candidateCommit: 'slice-2-commit' },
+    ]);
+    expect(result.slices[0]?.attempts).toEqual([
+      expect.objectContaining({ sliceIndex: 1, attempt: 0, route: 'advance' }),
+    ]);
+  });
+
+  it('repairs a red initial attempt from the original base at attempt 1', async () => {
+    const seededSlice = slice('seeded repair');
+    const runSlice = vi.fn().mockResolvedValue(attempt('repaired-commit', true));
+
+    const result = await runSlicePhase([seededSlice], 'start', {
+      runSlice,
+      maxRounds: 1,
+      initialAttempt: attempt('red-seed-commit', false),
+    });
+
+    expect(runSlice).toHaveBeenCalledTimes(1);
+    expect(runSlice).toHaveBeenCalledWith(seededSlice, 1, 'start', 1);
+    expect(result.slices[0]?.attempts).toEqual([
+      expect.objectContaining({ attempt: 0, candidateCommit: 'red-seed-commit', route: 'repair' }),
+      expect.objectContaining({ attempt: 1, candidateCommit: 'repaired-commit', route: 'advance' }),
+    ]);
+  });
+
+  it.each(['blocker', 'major'] as const)(
+    'routes a green verification with a %s review finding to halt',
+    async severity => {
+      const perSliceReview = review(severity);
+      const runSlice = vi.fn().mockResolvedValue({
+        ...attempt('reviewed-commit', true),
+        perSliceReview,
+      });
+
+      const result = await runSlicePhase([slice('reviewed')], 'start', {
+        runSlice,
+        maxRounds: 0,
+      });
+
+      expect(result).toMatchObject({
+        finalCandidateCommit: 'start',
+        haltedSliceIndex: 1,
+      });
+      expect(result.slices[0]).toMatchObject({
+        route: 'halt',
+        perSliceReview,
+        reasons: ['per-slice review found blocking findings'],
+      });
+      expect(result.slices[0]?.attempts[0]).toMatchObject({
+        perSliceReview,
+        route: 'halt',
+      });
+    },
+  );
+
+  it('repairs a green verification with a major review finding when a round remains', async () => {
+    const runSlice = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ...attempt('reviewed-commit', true),
+        perSliceReview: review('major'),
+      })
+      .mockResolvedValueOnce(attempt('clean-commit', true));
+
+    const result = await runSlicePhase([slice('review repair')], 'start', {
+      runSlice,
+      maxRounds: 1,
+    });
+
+    expect(result).toMatchObject({
+      finalCandidateCommit: 'clean-commit',
+      haltedSliceIndex: null,
+    });
+    expect(result.slices[0]).toMatchObject({ perSliceReview: null, route: 'advance' });
+    expect(result.slices[0]?.attempts).toEqual([
+      expect.objectContaining({
+        attempt: 0,
+        route: 'repair',
+        reasons: ['per-slice review found blocking findings'],
+      }),
+      expect.objectContaining({ attempt: 1, route: 'advance', reasons: [] }),
+    ]);
+  });
+
+  it.each([undefined, null])(
+    'preserves verification-only routing when review evidence is %s',
+    async perSliceReview => {
+      const runSlice = vi.fn().mockResolvedValue({
+        ...attempt('verified-commit', true),
+        ...(perSliceReview === undefined ? {} : { perSliceReview }),
+      });
+
+      const result = await runSlicePhase([slice('verification only')], 'start', {
+        runSlice,
+        maxRounds: 0,
+      });
+
+      expect(result).toMatchObject({
+        finalCandidateCommit: 'verified-commit',
+        haltedSliceIndex: null,
+      });
+      expect(result.slices[0]).toMatchObject({
+        route: 'advance',
+        perSliceReview: null,
+        reasons: [],
+      });
+    },
+  );
 
   it('halts a slice that stays red past the maximum rounds', async () => {
     const runSlice = vi
@@ -87,32 +232,106 @@ describe('runSlicePhase', () => {
   });
 
   it('retries a red slice and advances a later green attempt', async () => {
+    const firstRoleLogRefs = ['logs/attempt-0.log'];
+    const secondRoleLogRefs = ['logs/attempt-1.log'];
     const runSlice = vi
       .fn()
-      .mockResolvedValueOnce(attempt('failed-attempt', false))
-      .mockResolvedValueOnce(attempt('repaired-commit', true));
+      .mockResolvedValueOnce({
+        ...attempt('failed-attempt', false),
+        roleLogRefs: firstRoleLogRefs,
+      })
+      .mockResolvedValueOnce({
+        ...attempt('repaired-commit', true),
+        roleLogRefs: secondRoleLogRefs,
+      });
+    const observed: SliceAttemptEvidence[] = [];
 
     const result = await runSlicePhase([slice('repairable')], 'start', {
       runSlice,
       maxRounds: 2,
+      onAttempt: async evidence => {
+        observed.push({
+          ...evidence,
+          reasons: [...evidence.reasons],
+          roleLogRefs: [...evidence.roleLogRefs],
+        });
+        evidence.reasons.push('callback mutation');
+        evidence.roleLogRefs.push('logs/callback-mutation.log');
+      },
     });
 
     expect(result).toMatchObject({
       finalCandidateCommit: 'repaired-commit',
       haltedSliceIndex: null,
     });
-    expect(result.slices).toEqual([
-      expect.objectContaining({ route: 'advance', candidateCommit: 'repaired-commit', roundsUsed: 1 }),
+    expect(observed).toEqual([
+      expect.objectContaining({
+        sliceIndex: 1,
+        attempt: 0,
+        candidateCommit: 'failed-attempt',
+        route: 'repair',
+        reasons: ['slice verification failed'],
+        roleLogRefs: ['logs/attempt-0.log'],
+      }),
+      expect.objectContaining({
+        sliceIndex: 1,
+        attempt: 1,
+        candidateCommit: 'repaired-commit',
+        route: 'advance',
+        reasons: [],
+        roleLogRefs: ['logs/attempt-1.log'],
+      }),
     ]);
+    expect(result.slices).toEqual([
+      expect.objectContaining({
+        route: 'advance',
+        candidateCommit: 'repaired-commit',
+        roundsUsed: 1,
+        perSliceReview: null,
+        reasons: [],
+        roleLogRefs: ['logs/attempt-0.log', 'logs/attempt-1.log'],
+        attempts: observed,
+      }),
+    ]);
+    firstRoleLogRefs.push('logs/caller-mutation.log');
+    secondRoleLogRefs.length = 0;
+    expect(result.slices[0]?.attempts.map(entry => entry.roleLogRefs)).toEqual([
+      ['logs/attempt-0.log'],
+      ['logs/attempt-1.log'],
+    ]);
+    expect(result.slices[0]?.roleLogRefs).toEqual([
+      'logs/attempt-0.log',
+      'logs/attempt-1.log',
+    ]);
+    expect(result.slices[0]?.reasons).not.toBe(result.slices[0]?.attempts[1]?.reasons);
     expect(runSlice).toHaveBeenNthCalledWith(2, expect.anything(), 1, 'start', 1);
+  });
+
+  it('rejects failed attempt persistence before onSlice or another slice starts', async () => {
+    const runSlice = vi.fn().mockResolvedValue(attempt('candidate', true));
+    const onAttempt = vi.fn().mockRejectedValue(new Error('attempt persistence failed'));
+    const onSlice = vi.fn().mockResolvedValue(undefined);
+
+    await expect(runSlicePhase([slice('first'), slice('not run')], 'start', {
+      runSlice,
+      maxRounds: 1,
+      onAttempt,
+      onSlice,
+    })).rejects.toThrow('attempt persistence failed');
+
+    expect(runSlice).toHaveBeenCalledTimes(1);
+    expect(onAttempt).toHaveBeenCalledTimes(1);
+    expect(onSlice).not.toHaveBeenCalled();
   });
 
   it('halts immediately on a hard blocker', async () => {
     const runSlice = vi.fn().mockResolvedValue(attempt('blocked-commit', true, true));
+    const onAttempt = vi.fn().mockResolvedValue(undefined);
 
     const result = await runSlicePhase([slice('blocked'), slice('not run')], 'start', {
       runSlice,
       maxRounds: 2,
+      onAttempt,
     });
 
     expect(result).toMatchObject({
@@ -129,5 +348,12 @@ describe('runSlicePhase', () => {
       }),
     ]);
     expect(runSlice).toHaveBeenCalledTimes(1);
+    expect(onAttempt).toHaveBeenCalledOnce();
+    expect(onAttempt).toHaveBeenCalledWith(expect.objectContaining({
+      sliceIndex: 1,
+      attempt: 0,
+      route: 'halt',
+      reasons: ['unrecoverable blocker'],
+    }));
   });
 });

--- a/tests/runtime/pipeline/slice-runner.test.ts
+++ b/tests/runtime/pipeline/slice-runner.test.ts
@@ -22,12 +22,14 @@ function slice(objective: string): Slice {
 
 function verification(pass: boolean): VerificationReport {
   return {
+    reportVersion: '1',
     pass,
+    commandResults: [{ id: 'verify', exitCode: pass ? 0 : 1, ok: pass }],
     testsDeleted: 0,
     testsSkipped: 0,
     workspaceClean: true,
     scopeViolations: [],
-  } as unknown as VerificationReport;
+  };
 }
 
 function attempt(candidateCommit: string, pass: boolean, hardBlocker = false): SliceAttempt {
@@ -53,6 +55,41 @@ function review(severity: 'blocker' | 'major' | 'minor'): ConsolidationResult {
     }],
     contradictions: [],
   };
+}
+
+function evidencedAttempt(candidateCommit: string, severity: 'major' | 'minor' = 'minor') {
+  return {
+    ...attempt(candidateCommit, true),
+    perSliceReview: review(severity),
+    roleLogRefs: ['logs/objective.log'],
+  } satisfies SliceAttempt;
+}
+
+function mutateNestedEvidence(evidence: {
+  verification: VerificationReport | null;
+  perSliceReview?: ConsolidationResult | null;
+}): void {
+  if (evidence.verification === null || evidence.perSliceReview == null) {
+    throw new Error('test requires complete objective evidence');
+  }
+  evidence.verification.pass = false;
+  evidence.verification.commandResults[0]!.id = 'mutated';
+  evidence.verification.commandResults.push({ id: 'injected', exitCode: 1, ok: false });
+  evidence.verification.scopeViolations.push('mutated-scope');
+  evidence.perSliceReview.findings[0]!.severity = 'blocker';
+  evidence.perSliceReview.findings[0]!.reviewers.push('mutator');
+  evidence.perSliceReview.contradictions.push('mutated contradiction');
+}
+
+function expectObjectiveEvidence(
+  evidence: {
+    verification: VerificationReport | null;
+    perSliceReview?: ConsolidationResult | null;
+  },
+  severity: 'major' | 'minor' = 'minor',
+): void {
+  expect(evidence.verification).toEqual(verification(true));
+  expect(evidence.perSliceReview).toEqual(review(severity));
 }
 
 describe('runSlicePhase', () => {
@@ -307,6 +344,71 @@ describe('runSlicePhase', () => {
     expect(runSlice).toHaveBeenNthCalledWith(2, expect.anything(), 1, 'start', 1);
   });
 
+  it('snapshots the source attempt before onAttempt can mutate it', async () => {
+    const sourceAttempt = evidencedAttempt('source-commit');
+
+    const result = await runSlicePhase([slice('source isolation')], 'start', {
+      runSlice: vi.fn().mockResolvedValue(sourceAttempt),
+      maxRounds: 0,
+      onAttempt: async () => {
+        sourceAttempt.candidateCommit = 'mutated-source-commit';
+        sourceAttempt.hardBlocker = true;
+        sourceAttempt.roleLogRefs.push('logs/mutated-source.log');
+        mutateNestedEvidence(sourceAttempt);
+      },
+    });
+
+    expect(result).toMatchObject({
+      finalCandidateCommit: 'source-commit',
+      haltedSliceIndex: null,
+    });
+    expect(result.slices[0]).toMatchObject({
+      candidateCommit: 'source-commit',
+      route: 'advance',
+      reasons: [],
+      roleLogRefs: ['logs/objective.log'],
+    });
+    expectObjectiveEvidence(result.slices[0]!);
+    expect(result.slices[0]?.attempts[0]).toMatchObject({
+      candidateCommit: 'source-commit',
+      route: 'advance',
+      reasons: [],
+      roleLogRefs: ['logs/objective.log'],
+    });
+    expectObjectiveEvidence(result.slices[0]!.attempts[0]!);
+  });
+
+  it('isolates retained evidence from nested onAttempt mutations', async () => {
+    const result = await runSlicePhase([slice('attempt callback isolation')], 'start', {
+      runSlice: vi.fn().mockResolvedValue(evidencedAttempt('callback-commit')),
+      maxRounds: 0,
+      onAttempt: async evidence => {
+        evidence.candidateCommit = 'mutated-callback-commit';
+        evidence.reasons.push('mutated callback reason');
+        evidence.roleLogRefs.push('logs/mutated-callback.log');
+        mutateNestedEvidence(evidence);
+      },
+    });
+
+    expect(result).toMatchObject({
+      finalCandidateCommit: 'callback-commit',
+      haltedSliceIndex: null,
+    });
+    expect(result.slices[0]).toMatchObject({
+      candidateCommit: 'callback-commit',
+      route: 'advance',
+      reasons: [],
+      roleLogRefs: ['logs/objective.log'],
+    });
+    expectObjectiveEvidence(result.slices[0]!);
+    expect(result.slices[0]?.attempts[0]).toMatchObject({
+      candidateCommit: 'callback-commit',
+      reasons: [],
+      roleLogRefs: ['logs/objective.log'],
+    });
+    expectObjectiveEvidence(result.slices[0]!.attempts[0]!);
+  });
+
   it('rejects failed attempt persistence before onSlice or another slice starts', async () => {
     const runSlice = vi.fn().mockResolvedValue(attempt('candidate', true));
     const onAttempt = vi.fn().mockRejectedValue(new Error('attempt persistence failed'));
@@ -322,6 +424,74 @@ describe('runSlicePhase', () => {
     expect(runSlice).toHaveBeenCalledTimes(1);
     expect(onAttempt).toHaveBeenCalledTimes(1);
     expect(onSlice).not.toHaveBeenCalled();
+  });
+
+  it('isolates an advanced result from nested onSlice mutations', async () => {
+    const result = await runSlicePhase([slice('advance callback isolation')], 'start', {
+      runSlice: vi.fn().mockResolvedValue(evidencedAttempt('advanced-commit')),
+      maxRounds: 0,
+      onSlice: async terminal => {
+        terminal.candidateCommit = 'mutated-advanced-commit';
+        terminal.route = 'halt';
+        terminal.reasons.push('mutated callback reason');
+        terminal.roleLogRefs.push('logs/mutated-callback.log');
+        mutateNestedEvidence(terminal);
+        terminal.attempts[0]!.candidateCommit = 'mutated-attempt-commit';
+        mutateNestedEvidence(terminal.attempts[0]!);
+        terminal.attempts.length = 0;
+      },
+    });
+
+    expect(result).toMatchObject({
+      finalCandidateCommit: 'advanced-commit',
+      haltedSliceIndex: null,
+    });
+    expect(result.slices[0]).toMatchObject({
+      candidateCommit: 'advanced-commit',
+      route: 'advance',
+      reasons: [],
+      roleLogRefs: ['logs/objective.log'],
+    });
+    expectObjectiveEvidence(result.slices[0]!);
+    expect(result.slices[0]?.attempts).toHaveLength(1);
+    expect(result.slices[0]?.attempts[0]).toMatchObject({
+      candidateCommit: 'advanced-commit',
+      route: 'advance',
+    });
+    expectObjectiveEvidence(result.slices[0]!.attempts[0]!);
+  });
+
+  it('isolates a halted result from nested onSlice mutations', async () => {
+    const result = await runSlicePhase([slice('halt callback isolation')], 'start', {
+      runSlice: vi.fn().mockResolvedValue(evidencedAttempt('halted-commit', 'major')),
+      maxRounds: 0,
+      onSlice: async terminal => {
+        terminal.candidateCommit = 'mutated-halted-commit';
+        terminal.route = 'advance';
+        terminal.reasons.length = 0;
+        terminal.roleLogRefs.push('logs/mutated-callback.log');
+        mutateNestedEvidence(terminal);
+        terminal.attempts.length = 0;
+      },
+    });
+
+    expect(result).toMatchObject({
+      finalCandidateCommit: 'start',
+      haltedSliceIndex: 1,
+    });
+    expect(result.slices[0]).toMatchObject({
+      candidateCommit: 'halted-commit',
+      route: 'halt',
+      reasons: ['per-slice review found blocking findings'],
+      roleLogRefs: ['logs/objective.log'],
+    });
+    expectObjectiveEvidence(result.slices[0]!, 'major');
+    expect(result.slices[0]?.attempts).toHaveLength(1);
+    expect(result.slices[0]?.attempts[0]).toMatchObject({
+      candidateCommit: 'halted-commit',
+      route: 'halt',
+    });
+    expectObjectiveEvidence(result.slices[0]!.attempts[0]!, 'major');
   });
 
   it('halts immediately on a hard blocker', async () => {

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -77,9 +77,9 @@ describe("P0-A plugin wiring", () => {
     const marketplace = JSON.parse(read(".claude-plugin/marketplace.json"));
     const readme = read("README.md");
     const changelog = read("CHANGELOG.md");
-    assert.equal(plugin.version, "0.20.0");
-    assert.equal(marketplace.plugins[0].version, "0.20.0");
-    assert.match(readme, /badge\/version-0\.20\.0-/u);
+    assert.equal(plugin.version, "0.21.0");
+    assert.equal(marketplace.plugins[0].version, "0.21.0");
+    assert.match(readme, /badge\/version-0\.21\.0-/u);
     assert.doesNotMatch(
       readme,
       /`\/delegate`/u,

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -54,7 +54,7 @@ describe("P0-A plugin wiring", () => {
     const runtimeProtocol = /PROTOCOL_VERSION\s*=\s*"([^"]+)"/u.exec(versions)?.[1];
     const skill = read("skills/delegate/SKILL.md");
     const skillProtocol = /^PROTOCOL_VERSION:\s*([^\s]+)$/mu.exec(skill)?.[1];
-    assert.equal(runtimeProtocol, "1.2.0", "runtime must expose the current wire protocol");
+    assert.equal(runtimeProtocol, "1.3.0", "runtime must expose the current wire protocol");
     assert.equal(skillProtocol, runtimeProtocol, "delegate skill protocol marker must match runtime");
     assert.doesNotMatch(skill, /(^|[^:])\/delegate\b/mu, "delegate skill must use the fully qualified command");
     for (const lifecycleTool of ["delegate", "reviewCandidate", "decideCandidate", "integrateCandidate"]) {

--- a/tests/runtime/posix-platform-services.test.ts
+++ b/tests/runtime/posix-platform-services.test.ts
@@ -1,9 +1,11 @@
 import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PosixPlatformServices } from "../../src/platform/posix-platform-services.js";
 import { getPlatformServices } from "../../src/platform/select-platform.js";
 import { resolveStateDir } from "../../src/runtime/state-dir.js";
 import { scrubbedGitEnv } from "./helpers/git-fixture-env.js";
@@ -104,6 +106,25 @@ describe("PosixPlatformServices", () => {
     ]);
     expect(lockB.key).toBe(lockA.key);
     await lockB.release();
+  });
+
+  it("returns the canonical repository identity used to derive its lock key", async () => {
+    const repositoryIdentity = path.join(tempRoot, `common-${randomUUID()}`);
+    const directPs = Object.assign(new PosixPlatformServices(), {
+      async canonicalizePath(input: string) {
+        return { input, canonical: repoPath, gitCommonDir: repositoryIdentity };
+      },
+      async getProcessStartToken() { return null; },
+    });
+
+    const lock = await directPs.acquireCheckoutLock(repoPath);
+
+    try {
+      expect(lock.repositoryIdentity).toBe(repositoryIdentity);
+      expect(lock.key).toBe(createHash("sha256").update(repositoryIdentity).digest("hex"));
+    } finally {
+      await lock.release();
+    }
   });
 
   it("does not release a checkout lock that has been replaced by another owner", async () => {

--- a/tests/runtime/project-verifier.test.ts
+++ b/tests/runtime/project-verifier.test.ts
@@ -115,6 +115,30 @@ describe("projectVerify", () => {
     expect(await readFile(marker, "utf8")).toMatch(/verify-project-verifier$/);
   });
 
+  it("evaluates verificationId once to select its managed worktree name", async () => {
+    const fixture = await frozenFixture();
+    const marker = join(await temporaryDirectory("ca-project-verifier-marker-"), "cwd.txt");
+    let calls = 0;
+
+    await projectVerify({
+      repoRoot: fixture.repoRoot,
+      artifact: fixture.artifact,
+      commands: [command({
+        args: [
+          "-e",
+          `require('node:fs').writeFileSync(${JSON.stringify(marker)}, process.cwd())`,
+        ],
+      })],
+      verificationId: () => {
+        calls += 1;
+        return "slice-2-attempt-0";
+      },
+    });
+
+    expect(calls).toBe(1);
+    expect(await readFile(marker, "utf8")).toMatch(/verify-slice-2-attempt-0$/);
+  });
+
   it("records a passing Host-authorized command without mutation", async () => {
     const fixture = await frozenFixture();
 

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -345,6 +345,178 @@ describe("recoverStaleRuns", () => {
     expect(await runGit(repo.directory, ["rev-parse", neighborRef])).toBe(repo.head);
   }, { timeout: 120_000 });
 
+  it("waits for the checkout lease and preserves a run that completes while waiting", async () => {
+    const repo = await initRepo();
+    const runId = "run-completes-while-lease-waits";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+        async acquireCheckoutLock() {
+          // The producer reaches a terminal result while recovery waits for the
+          // lease; recovery must observe it and leave the run untouched.
+          await writeTerminalFailure(store, runId);
+          return { key: "test", repositoryIdentity: repo.commonDir, async release() {} };
+        },
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+
+    await expect(store.readResult(runId)).resolves.toMatchObject({ status: "failed" });
+  });
+
+  it("preserves an unfinished run when its marker becomes live while the lease waits", async () => {
+    const repo = await initRepo();
+    const runId = "run-marker-live-while-lease-waits";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return "darwin:live"; },
+        async terminateProcessTreeByPid() {},
+        async acquireCheckoutLock() {
+          await store.writePipelineActiveMarker({
+            pid: 9191,
+            processToken: "darwin:live",
+            startedAt: "2026-07-18T12:00:00.000Z",
+            sliced: false,
+          });
+          return { key: "test", repositoryIdentity: repo.commonDir, async release() {} };
+        },
+      },
+      isProcessAlive: pid => pid === 9191,
+    })).resolves.toEqual({ recovered: [] });
+
+    await expect(store.readResult(runId)).resolves.toBeNull();
+  });
+
+  it("preserves a replacement live run-start owner installed while the lease waits", async () => {
+    const repo = await initRepo();
+    const runId = "run-replacement-owner-while-lease-waits";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    const lockKey = createHash("sha256").update(repo.commonDir).digest("hex");
+    const runStartPath = path.join(store.runDirectory, "run-start.json");
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return "darwin:new-owner"; },
+        async terminateProcessTreeByPid() {},
+        async acquireCheckoutLock() {
+          // A fresh, live owner claims the same run while we wait for the lease.
+          await writeFile(runStartPath, `${JSON.stringify({
+            runId,
+            lockKey,
+            canonicalCommonDir: repo.commonDir,
+            pid: 7373,
+            processToken: "darwin:new-owner",
+            startedAt: "2026-07-18T12:30:00.000Z",
+          })}\n`);
+          return { key: "test", repositoryIdentity: repo.commonDir, async release() {} };
+        },
+      },
+      isProcessAlive: pid => pid === 7373,
+    })).resolves.toEqual({ recovered: [] });
+
+    await expect(store.readResult(runId)).resolves.toBeNull();
+  });
+
+  it("exposes both recovery and release failures and releases exactly once", async () => {
+    const repo = await initRepo();
+    const runId = "run-recovery-and-release-fail";
+    await createUnfinishedRun(runId, repo.commonDir, null);
+    let releases = 0;
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+        async acquireCheckoutLock() {
+          return {
+            key: "test",
+            repositoryIdentity: "/identity/that/does/not/match",
+            async release() { releases += 1; throw new Error("release boom"); },
+          };
+        },
+      },
+      isProcessAlive: () => false,
+    })).rejects.toThrow(AggregateError);
+
+    expect(releases).toBe(1);
+  });
+
+  it("fails visibly when the acquired checkout identity differs", async () => {
+    const repo = await initRepo();
+    const runId = "run-lease-identity-differs";
+    await createUnfinishedRun(runId, repo.commonDir, null);
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+        async acquireCheckoutLock() {
+          return {
+            key: "test",
+            repositoryIdentity: "/identity/that/does/not/match",
+            async release() {},
+          };
+        },
+      },
+      isProcessAlive: () => false,
+    })).rejects.toThrow("checkout lease repository identity changed during recovery");
+  });
+
+  it("preserves a malformed lock during the broad reclaim sweep", async () => {
+    // No stale runs: exercise only the end-of-recovery broad lock sweep.
+    const locksRoot = path.join(process.env.CLAUDE_PLUGIN_DATA!, "locks");
+    await mkdir(locksRoot, { recursive: true });
+    const strayLock = path.join(locksRoot, `${"de".repeat(32)}.lock`);
+    await writeFile(strayLock, "not-json-not-a-pid");
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+
+    // A lock whose owner cannot be parsed is never unlinked blindly.
+    await expect(access(strayLock)).resolves.toBeUndefined();
+  });
+
+  it("refuses to unlink a malformed exact lock and fails closed", async () => {
+    const repo = await initRepo();
+    const runId = "run-malformed-exact-lock";
+    await createUnfinishedRun(runId, repo.commonDir, null);
+    const locksRoot = path.join(process.env.CLAUDE_PLUGIN_DATA!, "locks");
+    await mkdir(locksRoot, { recursive: true });
+    // The exact checkout lock key for this run carries unparseable bytes.
+    const exactLockKey = createHash("sha256").update(repo.commonDir).digest("hex");
+    const exactLock = path.join(locksRoot, `${exactLockKey}.lock`);
+    await writeFile(exactLock, "not-json-not-a-pid");
+
+    // reclaimExactLock refuses to remove it, so the checkout lease cannot be
+    // acquired — recovery fails closed rather than force-clearing the lock.
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).rejects.toThrow("checkout is locked");
+
+    await expect(access(exactLock)).resolves.toBeUndefined();
+  });
+
   it("cleans every sliced worktree and ref for an unfinished run idempotently", async () => {
     const repo = await initRepo();
     const runId = "run-sliced-unfinished";

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -202,7 +202,7 @@ afterEach(async () => {
 });
 
 describe("recoverStaleRuns", () => {
-  it("downgrades a verified candidate before clearing a dead pipeline marker", async () => {
+  it("downgrades a verified candidate before clearing a dead sliced pipeline marker", async () => {
     const repo = await initRepo();
     const runId = "run-interrupted-pipeline-authority";
     const store = await createUnfinishedRun(runId, repo.commonDir, null);
@@ -211,6 +211,7 @@ describe("recoverStaleRuns", () => {
       pid: 4242,
       processToken: "darwin:dead",
       startedAt: "2026-07-18T12:00:00.000Z",
+      sliced: true,
     });
 
     await expect(recoverStaleRuns({
@@ -230,6 +231,61 @@ describe("recoverStaleRuns", () => {
       evidence: {
         pipelineRecovery: "interrupted-before-terminal-cleanup",
       },
+    });
+    await expectMissing(path.join(store.runDirectory, "pipeline-active.json"));
+  });
+
+  it("preserves a verified candidate while clearing a dead non-sliced pipeline marker", async () => {
+    const repo = await initRepo();
+    const runId = "run-interrupted-non-sliced-pipeline";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    await writeVerifiedCandidate(store, runId, repo);
+    await store.writePipelineActiveMarker({
+      pid: 4242,
+      processToken: "darwin:dead",
+      startedAt: "2026-07-18T12:00:00.000Z",
+      sliced: false,
+    });
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+
+    await expect(store.readResult(runId)).resolves.toMatchObject({
+      status: "verified-candidate",
+      failure: null,
+    });
+    await expectMissing(path.join(store.runDirectory, "pipeline-active.json"));
+  });
+
+  it("treats a legacy pipeline marker as non-sliced during recovery", async () => {
+    const repo = await initRepo();
+    const runId = "run-interrupted-legacy-pipeline";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    await writeVerifiedCandidate(store, runId, repo);
+    await writeFile(path.join(store.runDirectory, "pipeline-active.json"), `${JSON.stringify({
+      pid: 4242,
+      processToken: "darwin:dead",
+      startedAt: "2026-07-18T12:00:00.000Z",
+    })}\n`);
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+
+    await expect(store.readResult(runId)).resolves.toMatchObject({
+      status: "verified-candidate",
+      failure: null,
     });
     await expectMissing(path.join(store.runDirectory, "pipeline-active.json"));
   });
@@ -257,6 +313,7 @@ describe("recoverStaleRuns", () => {
       pid: 4242,
       processToken: "darwin:dead",
       startedAt: "2026-07-18T12:00:00.000Z",
+      sliced: true,
     });
 
     await expect(recoverStaleRuns({
@@ -366,6 +423,61 @@ describe("recoverStaleRuns", () => {
     await expect(store.readResult(runId)).resolves.toBeNull();
   });
 
+  it("rejects a non-commit slice ref even when a replacement object spoofs its type", async () => {
+    const repo = await initRepo();
+    const runId = "run-sliced-replacement-spoof";
+    await createUnfinishedRun(runId, repo.commonDir, null);
+    const sliceRef = `refs/claude-architect/slices/${runId}/slice-2-attempt-0`;
+    const treeOid = await runGit(repo.directory, ["rev-parse", `${repo.head}^{tree}`]);
+    await runGit(repo.directory, ["update-ref", sliceRef, treeOid]);
+    await runGit(repo.directory, ["update-ref", `refs/replace/${treeOid}`, repo.head]);
+    expect(await runGit(repo.directory, ["cat-file", "-t", treeOid])).toBe("commit");
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).rejects.toThrow("temporary slice ref does not identify a commit during recovery");
+
+    expect(await runGit(repo.directory, ["rev-parse", sliceRef])).toBe(treeOid);
+  });
+
+  it("disables replacement objects only for temporary-ref object type validation", async () => {
+    const repo = await initRepo();
+    const runId = "run-sliced-no-replace-scope";
+    await createUnfinishedRun(runId, repo.commonDir, null);
+    const sliceRef = `refs/claude-architect/slices/${runId}/slice-2-attempt-0`;
+    await runGit(repo.directory, ["update-ref", sliceRef, repo.head]);
+    const observed: Array<{ command: string; noReplace: string | undefined }> = [];
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+      git: async (cwd, args, options) => {
+        observed.push({
+          command: args[0] ?? "",
+          noReplace: typeof options === "object"
+            ? options.env?.GIT_NO_REPLACE_OBJECTS
+            : undefined,
+        });
+        return git(cwd, args, options);
+      },
+    })).resolves.toEqual({ recovered: [runId] });
+
+    expect(observed.filter(call => call.command === "cat-file"))
+      .toEqual([{ command: "cat-file", noReplace: "1" }]);
+    expect(observed.filter(call => call.command !== "cat-file").every(
+      call => call.noReplace === undefined,
+    )).toBe(true);
+  });
+
   it("fails closed when a slice ref moves after recovery enumeration", async () => {
     const repo = await initRepo();
     const runId = "run-sliced-moved-ref";
@@ -439,6 +551,7 @@ describe("recoverStaleRuns", () => {
       pid: 4242,
       processToken: "darwin:dead",
       startedAt: "2026-07-18T12:00:00.000Z",
+      sliced: false,
     });
 
     await expect(recoverStaleRuns({
@@ -493,6 +606,7 @@ describe("recoverStaleRuns", () => {
       pid: 4242,
       processToken: null,
       startedAt: "2026-07-18T12:00:00.000Z",
+      sliced: false,
     });
 
     await expect(recoverStaleRuns({

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -17,6 +17,7 @@ import { WorktreeManager } from "../../src/git/worktree-manager.js";
 import { start } from "../../src/mcp/server.js";
 import { ArtifactStore } from "../../src/runtime/artifact-store.js";
 import { recoverStaleRuns } from "../../src/runtime/recovery-manager.js";
+import { buildRunManifest } from "../../src/runtime/run-manifest.js";
 
 const serverEvents = vi.hoisted(() => [] as string[]);
 
@@ -84,6 +85,102 @@ async function createUnfinishedRun(
   return store;
 }
 
+function slicedManagedIds(runId: string): string[] {
+  return [
+    `${runId}-slice-1-attempt-0`,
+    `${runId}-slice-1-attempt-0-review`,
+    `${runId}-slice-1-attempt-0-verify`,
+    `verify-${runId}-slice-1-attempt-0-pipeline`,
+    `${runId}-composed-review`,
+    `${runId}-final-verify`,
+    `verify-${runId}-final-pipeline`,
+  ];
+}
+
+async function createManagedWorktrees(
+  repo: { directory: string; head: string },
+  managedIds: string[],
+): Promise<Array<{ path: string; cleanup(): Promise<void> }>> {
+  const worktrees: Array<{ path: string; cleanup(): Promise<void> }> = [];
+  for (const managedId of managedIds) {
+    worktrees.push(await new WorktreeManager(repo.directory, managedId).create(repo.head));
+  }
+  return worktrees;
+}
+
+async function writeTerminalFailure(store: ArtifactStore, runId: string): Promise<void> {
+  await store.writeResult({
+    resultVersion: "1",
+    runId,
+    status: "failed",
+    failure: "producer-failure",
+    summary: "pipeline failed",
+    producerSummary: null,
+    candidate: null,
+    requestedVerification: [],
+    executedVerification: [],
+    unresolvedIssues: [],
+    evidence: {},
+    logsRef: "logs/producer.log",
+    producerId: null,
+    producerVersion: null,
+    producerModel: null,
+    durationMs: 1,
+    sessionId: null,
+  });
+}
+
+async function writeVerifiedCandidate(
+  store: ArtifactStore,
+  runId: string,
+  repo: { directory: string; head: string },
+): Promise<void> {
+  const tree = await runGit(repo.directory, ["rev-parse", `${repo.head}^{tree}`]);
+  const manifestHash = createHash("sha256").update("[]").digest("hex");
+  const anchorRef = `refs/claude-architect/candidates/${runId}`;
+  await runGit(repo.directory, ["update-ref", anchorRef, repo.head]);
+  await store.writeResult({
+    resultVersion: "1",
+    runId,
+    status: "verified-candidate",
+    failure: null,
+    summary: "candidate produced and independently verified",
+    producerSummary: "test producer",
+    candidate: {
+      baseCommitOid: repo.head,
+      candidateTreeOid: tree,
+      candidateCommitOid: repo.head,
+      anchorRef,
+      manifestHash,
+      changedPaths: [],
+      patch: "",
+    },
+    requestedVerification: [],
+    executedVerification: [],
+    unresolvedIssues: [],
+    evidence: {},
+    logsRef: "logs/producer.log",
+    producerId: "stub",
+    producerVersion: "1",
+    producerModel: null,
+    durationMs: 1,
+    sessionId: null,
+  });
+  await store.writeManifest(buildRunManifest({
+    runId,
+    repoRoot: repo.directory,
+    baseCommitOid: repo.head,
+    candidateManifestHash: manifestHash,
+    producer: { id: "stub", version: "1", model: null },
+    effectivePolicy: { isolation: "temporary-home", retries: 0 },
+    repositoryInstructions: [],
+    prompt: "test",
+    executionPolicy: { network: "denied", writeAllowlist: ["**"] },
+    environment: [],
+    packagedVerifier: { version: "1", content: "test" },
+  }));
+}
+
 beforeEach(async () => {
   previousPluginData = process.env.CLAUDE_PLUGIN_DATA;
   previousDelegated = process.env.CLAUDE_ARCHITECT_DELEGATED;
@@ -105,6 +202,207 @@ afterEach(async () => {
 });
 
 describe("recoverStaleRuns", () => {
+  it("downgrades a verified candidate before clearing a dead pipeline marker", async () => {
+    const repo = await initRepo();
+    const runId = "run-interrupted-pipeline-authority";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    await writeVerifiedCandidate(store, runId, repo);
+    await store.writePipelineActiveMarker({
+      pid: 4242,
+      processToken: "darwin:dead",
+      startedAt: "2026-07-18T12:00:00.000Z",
+    });
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+
+    await expect(store.readResult(runId)).resolves.toMatchObject({
+      status: "failed",
+      failure: "verification-failure",
+      candidate: expect.any(Object),
+      unresolvedIssues: ["pipeline-interrupted-before-terminal-cleanup"],
+      evidence: {
+        pipelineRecovery: "interrupted-before-terminal-cleanup",
+      },
+    });
+    await expectMissing(path.join(store.runDirectory, "pipeline-active.json"));
+  });
+
+  it("cleans every sliced worktree and ref for a terminal run without touching a prefix neighbor", async () => {
+    const repo = await initRepo();
+    const runId = "run-sliced-terminal";
+    const neighborRunId = `${runId}-neighbor`;
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    await writeTerminalFailure(store, runId);
+    const slicedWorktrees = await createManagedWorktrees(repo, slicedManagedIds(runId));
+    const neighborWorktree = (await createManagedWorktrees(
+      repo,
+      [`${neighborRunId}-slice-1-attempt-0`],
+    ))[0]!;
+    const sliceRefs = [
+      `refs/claude-architect/slices/${runId}/slice-1-attempt-1`,
+      `refs/claude-architect/slices/${runId}/slice-2-attempt-0`,
+    ];
+    const neighborRef = `refs/claude-architect/slices/${neighborRunId}/slice-1-attempt-0`;
+    for (const ref of [...sliceRefs, neighborRef]) {
+      await runGit(repo.directory, ["update-ref", ref, repo.head]);
+    }
+    await store.writePipelineActiveMarker({
+      pid: 4242,
+      processToken: "darwin:dead",
+      startedAt: "2026-07-18T12:00:00.000Z",
+    });
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+
+    await Promise.all(slicedWorktrees.map(worktree => expectMissing(worktree.path)));
+    await expect(access(neighborWorktree.path)).resolves.toBeUndefined();
+    for (const ref of sliceRefs) {
+      expect((await git(repo.directory, ["rev-parse", "--verify", "--quiet", ref])).exitCode)
+        .not.toBe(0);
+    }
+    expect(await runGit(repo.directory, ["rev-parse", neighborRef])).toBe(repo.head);
+    await expectMissing(path.join(store.runDirectory, "pipeline-active.json"));
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+    await expect(access(neighborWorktree.path)).resolves.toBeUndefined();
+    expect(await runGit(repo.directory, ["rev-parse", neighborRef])).toBe(repo.head);
+  }, { timeout: 120_000 });
+
+  it("cleans every sliced worktree and ref for an unfinished run idempotently", async () => {
+    const repo = await initRepo();
+    const runId = "run-sliced-unfinished";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    const slicedWorktrees = await createManagedWorktrees(repo, slicedManagedIds(runId));
+    const sliceRefs = [
+      `refs/claude-architect/slices/${runId}/slice-1-attempt-1`,
+      `refs/claude-architect/slices/${runId}/slice-2-attempt-0`,
+    ];
+    for (const ref of sliceRefs) await runGit(repo.directory, ["update-ref", ref, repo.head]);
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [runId] });
+
+    await Promise.all(slicedWorktrees.map(worktree => expectMissing(worktree.path)));
+    for (const ref of sliceRefs) {
+      expect((await git(repo.directory, ["rev-parse", "--verify", "--quiet", ref])).exitCode)
+        .not.toBe(0);
+    }
+    await expect(store.readResult(runId)).resolves.toMatchObject({ status: "cancelled" });
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [] });
+  }, { timeout: 120_000 });
+
+  it("fails closed on a malformed ref inside the run-specific slice namespace", async () => {
+    const repo = await initRepo();
+    const runId = "run-sliced-malformed-ref";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    const malformedRef = `refs/claude-architect/slices/${runId}/unexpected`;
+    await runGit(repo.directory, ["update-ref", malformedRef, repo.head]);
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).rejects.toThrow("temporary slice ref name is malformed during recovery");
+
+    expect(await runGit(repo.directory, ["rev-parse", malformedRef])).toBe(repo.head);
+    await expect(store.readResult(runId)).resolves.toBeNull();
+  });
+
+  it("fails closed when a slice ref points to a tag that peels to a commit", async () => {
+    const repo = await initRepo();
+    const runId = "run-sliced-tag-ref";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    const sliceRef = `refs/claude-architect/slices/${runId}/slice-2-attempt-0`;
+    await runGit(repo.directory, ["tag", "-a", "slice-tag", "-m", "slice tag", repo.head]);
+    const tagOid = await runGit(repo.directory, ["rev-parse", "refs/tags/slice-tag"]);
+    await runGit(repo.directory, ["update-ref", sliceRef, tagOid]);
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).rejects.toThrow("temporary slice ref does not identify a commit during recovery");
+
+    expect(await runGit(repo.directory, ["rev-parse", sliceRef])).toBe(tagOid);
+    await expect(store.readResult(runId)).resolves.toBeNull();
+  });
+
+  it("fails closed when a slice ref moves after recovery enumeration", async () => {
+    const repo = await initRepo();
+    const runId = "run-sliced-moved-ref";
+    const store = await createUnfinishedRun(runId, repo.commonDir, null);
+    const sliceRef = `refs/claude-architect/slices/${runId}/slice-2-attempt-0`;
+    await runGit(repo.directory, ["update-ref", sliceRef, repo.head]);
+    const movedOid = await runGit(repo.directory, [
+      "commit-tree",
+      `${repo.head}^{tree}`,
+      "-p",
+      repo.head,
+      "-m",
+      "moved slice ref",
+    ]);
+    let moved = false;
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+      git: async (cwd, args, options) => {
+        const result = await git(cwd, args, options);
+        if (!moved && args[0] === "for-each-ref") {
+          moved = true;
+          await runGit(repo.directory, ["update-ref", sliceRef, movedOid, repo.head]);
+        }
+        return result;
+      },
+    })).rejects.toThrow("temporary slice ref moved during recovery");
+
+    expect(await runGit(repo.directory, ["rev-parse", sliceRef])).toBe(movedOid);
+    await expect(store.readResult(runId)).resolves.toBeNull();
+  });
+
   it("cleans dead-owner pipeline worktrees for a terminal run", async () => {
     const repo = await initRepo();
     const runId = "run-dead-pipeline";

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -331,7 +331,11 @@ describe("recoverStaleRuns", () => {
     await expect(store.readResult(runId)).resolves.toBeNull();
   }, { timeout: 120_000 });
 
-  it("preserves a primary recovery error when lock releases also fail", async () => {
+  // POSIX-only: the release failure is forced by rm-ing the locks directory while
+  // recovery holds recovery.lock open. Windows blocks removing a directory that
+  // contains an open handle, so the trigger cannot be reproduced; the AggregateError
+  // composition it checks is platform-independent and covered by the POSIX run.
+  it.skipIf(process.platform === "win32")("preserves a primary recovery error when lock releases also fail", async () => {
     const repo = await initRepo();
     const runId = "run-primary-and-release-failure";
     await createUnfinishedRun(runId, repo.commonDir, 4242, "darwin:live");
@@ -465,7 +469,11 @@ describe("recoverStaleRuns", () => {
     await expect(readFile(lockPath, "utf8")).resolves.toBe("9103");
   }, { timeout: 120_000 });
 
-  it("preserves a replacement lock swapped during owner token probing", async () => {
+  // POSIX-only: this simulates a concurrent process renaming a replacement lock onto
+  // the lock file while the reclaimer holds it open for owner probing. Windows blocks
+  // renaming onto an open file at the OS level, so the swap cannot occur — the OS
+  // itself enforces the property the reclaimer's TOCTOU guard proves on POSIX.
+  it.skipIf(process.platform === "win32")("preserves a replacement lock swapped during owner token probing", async () => {
     const locksRoot = path.join(process.env.CLAUDE_PLUGIN_DATA!, "locks");
     const lockPath = path.join(locksRoot, `${"f".repeat(64)}.lock`);
     const replacementPath = path.join(locksRoot, "replacement.lock");

--- a/tests/runtime/tools.test.ts
+++ b/tests/runtime/tools.test.ts
@@ -193,6 +193,7 @@ function fakePlatform(): PlatformServices {
     }),
     acquireCheckoutLock: async checkout => ({
       key: checkout,
+      repositoryIdentity: "/canonical/repo/.git",
       release: async () => {},
     }),
   } as PlatformServices;

--- a/tests/runtime/tools.test.ts
+++ b/tests/runtime/tools.test.ts
@@ -16,9 +16,8 @@ import {
   type ToolArtifactStore,
   type ToolDependencies,
 } from "../../src/mcp/tools.js";
-import { withRepoLock } from "../../src/mcp/serialize.js";
 import type { PipelineResult } from "../../src/pipeline/pipeline-runtime.js";
-import type { PlatformServices } from "../../src/platform/platform-services.js";
+import type { CheckoutLock, PlatformServices } from "../../src/platform/platform-services.js";
 import { getPlatformServices } from "../../src/platform/select-platform.js";
 import type { AttemptResult, CandidateArtifact } from "../../src/protocol/attempt-result.js";
 import type { DelegationSpec } from "../../src/protocol/delegation-spec.js";
@@ -199,26 +198,6 @@ function fakePlatform(): PlatformServices {
   } as PlatformServices;
 }
 
-async function holdRepoLock(key: string): Promise<() => Promise<void>> {
-  let markHeld!: () => void;
-  let allowRelease!: () => void;
-  const held = new Promise<void>(resolve => { markHeld = resolve; });
-  const releaseAllowed = new Promise<void>(resolve => { allowRelease = resolve; });
-  const pending = withRepoLock(key, async () => {
-    markHeld();
-    await releaseAllowed;
-  });
-  await held;
-  return async () => {
-    allowRelease();
-    await pending;
-  };
-}
-
-async function waitForLockQueue(): Promise<void> {
-  await new Promise<void>(resolve => setImmediate(resolve));
-}
-
 function gitResult(stdout = "", exitCode = 0): GitResult {
   return { stdout, stderr: "", exitCode };
 }
@@ -247,6 +226,25 @@ function dependencies(
       detail: "candidate tree applied",
     }),
   };
+}
+
+type LifecycleOperation = "review" | "decide" | "integrate";
+
+function invokeLifecycle(
+  operation: LifecycleOperation,
+  checkoutPath: string,
+  deps: ToolDependencies,
+): Promise<unknown> {
+  if (operation === "review") return handleReviewCandidate(checkoutPath, "run-tools", deps);
+  if (operation === "decide") {
+    return handleDecideCandidate(checkoutPath, "run-tools", "accepted", deps);
+  }
+  return handleIntegrateCandidate(
+    checkoutPath,
+    "run-tools",
+    candidate.manifestHash,
+    deps,
+  );
 }
 
 async function git(cwd: string, args: string[]): Promise<string> {
@@ -519,25 +517,32 @@ describe("MCP tool handlers", () => {
   });
 
   it.each(["review", "decide", "integrate"] as const)(
-    "reloads the archive after a queued %s lifecycle request acquires the repository lock",
+    "reloads failed sliced authority after a queued %s acquires the checkout file lease",
     async operation => {
-      const store = new FakeStore();
+      const repoRoot = await createRepository();
+      const platformServices = getPlatformServices();
+      const store = new FakeStore(result, manifestFor(repoRoot));
       if (operation === "integrate") {
         store.decision = { decision: "accepted", recordedAt: "2026-07-19T00:00:00.000Z" };
       }
-      let markCallerCanonicalized!: () => void;
-      const callerCanonicalized = new Promise<void>(resolve => {
-        markCallerCanonicalized = resolve;
-      });
-      const basePlatform = fakePlatform();
-      const ps = {
-        ...basePlatform,
-        canonicalizePath: async (input: string) => {
-          const canonical = await basePlatform.canonicalizePath(input);
-          if (input === "/supplied/repo") markCallerCanonicalized();
-          return canonical;
+      let markAcquiring!: () => void;
+      const acquisitionStarted = new Promise<void>(resolve => { markAcquiring = resolve; });
+      let acquireCalls = 0;
+      let releaseCalls = 0;
+      const ps = Object.assign(Object.create(platformServices), {
+        async acquireCheckoutLock(checkout: string): Promise<CheckoutLock> {
+          acquireCalls += 1;
+          markAcquiring();
+          const lock = await platformServices.acquireCheckoutLock(checkout);
+          return {
+            ...lock,
+            async release() {
+              releaseCalls += 1;
+              await lock.release();
+            },
+          };
         },
-      } as PlatformServices;
+      }) as PlatformServices;
       const deps = dependencies(store, ps);
       let gitCalls = 0;
       let integrationCalls = 0;
@@ -550,24 +555,18 @@ describe("MCP tool handlers", () => {
         integrationCalls += 1;
         return { integration: "applied", detail: "candidate tree applied" };
       };
-      const releaseLock = await holdRepoLock("/canonical/repo/.git");
-      const pending = operation === "review"
-        ? handleReviewCandidate("/supplied/repo", "run-tools", deps)
-        : operation === "decide"
-          ? handleDecideCandidate("/supplied/repo", "run-tools", "accepted", deps)
-          : handleIntegrateCandidate(
-            "/supplied/repo",
-            "run-tools",
-            candidate.manifestHash,
-            deps,
-          );
-
-      await callerCanonicalized;
-      await waitForLockQueue();
+      const heldLock = await platformServices.acquireCheckoutLock(repoRoot);
+      const pending = invokeLifecycle(operation, repoRoot, deps);
+      const first = await Promise.race([
+        acquisitionStarted.then(() => "acquiring" as const),
+        pending.then(() => "settled" as const),
+      ]);
       store.storedResult = failedSlicedResult;
-      await releaseLock();
+      await heldLock.release();
+      const output = await pending;
 
-      await expect(pending).resolves.toEqual(operation === "review"
+      expect.soft(first).toBe("acquiring");
+      expect.soft(output).toEqual(operation === "review"
         ? {
           ok: false,
           error: "candidate-not-found",
@@ -578,56 +577,74 @@ describe("MCP tool handlers", () => {
           error: "candidate-not-verified",
           diagnostic: "candidate did not complete independent verification",
         });
-      expect(gitCalls).toBe(0);
-      expect(integrationCalls).toBe(0);
-      if (operation === "decide") expect(store.decision).toBeNull();
+      expect.soft(acquireCalls).toBe(1);
+      expect.soft(releaseCalls).toBe(1);
+      expect.soft(gitCalls).toBe(0);
+      expect.soft(integrationCalls).toBe(0);
+      if (operation === "decide") expect.soft(store.decision).toBeNull();
     },
   );
 
-  it("rejects an archived repository identity that changes before the queued archive load", async () => {
-    const repoA = "/canonical/repo-a";
-    const repoB = "/canonical/repo-b";
-    const callerPath = "/supplied/repo-a";
-    const store = new FakeStore(result, { ...manifest, repoRoot: repoA });
-    let markCallerCanonicalized!: () => void;
-    const callerCanonicalized = new Promise<void>(resolve => {
-      markCallerCanonicalized = resolve;
-    });
-    const ps = {
-      ...fakePlatform(),
-      canonicalizePath: async (input: string) => {
-        if (input === callerPath) {
-          markCallerCanonicalized();
-          return { input, canonical: repoA, gitCommonDir: `${repoA}/.git` };
-        }
-        if (input === repoA || input === repoB) {
-          return { input, canonical: input, gitCommonDir: `${input}/.git` };
-        }
-        throw new Error(`unexpected path: ${input}`);
-      },
-    } as PlatformServices;
-    const deps = dependencies(store, ps);
-    let gitCalls = 0;
-    const originalGit = deps.git!;
-    deps.git = async (cwd, args, indexFile) => {
-      gitCalls += 1;
-      return originalGit(cwd, args, indexFile);
-    };
-    const releaseLock = await holdRepoLock(`${repoA}/.git`);
-    const pending = handleReviewCandidate(callerPath, "run-tools", deps);
+  it.each(["review", "decide", "integrate"] as const)(
+    "rejects %s caller identity drift before loading archive authority",
+    async operation => {
+      const callerIdentity = "/canonical/repo-a/.git";
+      const acquisitionIdentity = "/canonical/repo-b/.git";
+      const store = new FakeStore();
+      if (operation === "integrate") {
+        store.decision = { decision: "accepted", recordedAt: "2026-07-19T00:00:00.000Z" };
+      }
+      let acquireCalls = 0;
+      let releaseCalls = 0;
+      let storeFactoryCalls = 0;
+      const ps = {
+        ...fakePlatform(),
+        canonicalizePath: async (input: string) => ({
+          input,
+          canonical: "/canonical/repo-a",
+          gitCommonDir: callerIdentity,
+        }),
+        acquireCheckoutLock: async (): Promise<CheckoutLock> => {
+          acquireCalls += 1;
+          return {
+            key: "acquisition-lock",
+            repositoryIdentity: acquisitionIdentity,
+            async release() { releaseCalls += 1; },
+          };
+        },
+      } as PlatformServices;
+      const deps = dependencies(store, ps);
+      deps.storeFactory = () => {
+        storeFactoryCalls += 1;
+        return store;
+      };
+      let gitCalls = 0;
+      let integrationCalls = 0;
+      const originalGit = deps.git!;
+      deps.git = async (cwd, args, indexFile) => {
+        gitCalls += 1;
+        return originalGit(cwd, args, indexFile);
+      };
+      deps.applyCandidateTree = async () => {
+        integrationCalls += 1;
+        return { integration: "applied", detail: "candidate tree applied" };
+      };
 
-    await callerCanonicalized;
-    await waitForLockQueue();
-    store.storedManifest = { ...manifest, repoRoot: repoB };
-    await releaseLock();
+      const output = await invokeLifecycle(operation, "/supplied/repo-a", deps);
 
-    await expect(pending).resolves.toEqual({
-      ok: false,
-      error: "run-checkout-mismatch",
-      diagnostic: "candidate run belongs to a different repository than the supplied checkoutPath",
-    });
-    expect(gitCalls).toBe(0);
-  });
+      expect.soft(output).toEqual({
+        ok: false,
+        error: "run-checkout-mismatch",
+        diagnostic: "supplied checkout repository identity changed before checkout lease acquisition",
+      });
+      expect.soft(acquireCalls).toBe(1);
+      expect.soft(releaseCalls).toBe(1);
+      expect.soft(storeFactoryCalls).toBe(0);
+      expect.soft(gitCalls).toBe(0);
+      expect.soft(integrationCalls).toBe(0);
+      if (operation === "decide") expect.soft(store.decision).toBeNull();
+    },
+  );
 
   it("holds the checkout file lock while recording a decision and releases it afterwards", async () => {
     const repoRoot = await createRepository();
@@ -784,7 +801,7 @@ describe("MCP tool handlers", () => {
     let integrationCalls = 0;
     deps.applyCandidateTree = async args => {
       integrationCalls += 1;
-      expect(args).toEqual({
+      expect(args).toMatchObject({
         repoRoot: "/canonical/repo",
         artifact: candidate,
         expectedArtifactHash: candidate.manifestHash,
@@ -819,55 +836,203 @@ describe("MCP tool handlers", () => {
     expect(integrationCalls).toBe(1);
   });
 
-  it("refuses to decide while the delegation pipeline is active", async () => {
+  it("passes the exact lifecycle checkout lease into integration without nested ownership", async () => {
     const store = new FakeStore();
-    store.pipelineActiveMarker = {
-      pid: process.pid,
-      processToken: null,
-      startedAt: "2026-07-18T12:00:00.000Z",
-      sliced: true,
-    };
-
-    await expect(handleDecideCandidate(
-      "/canonical/repo",
-      "run-tools",
-      "accepted",
-      dependencies(store),
-    )).resolves.toEqual({
-      ok: false,
-      error: "pipeline-active",
-      diagnostic: "the delegation pipeline for this run is still active",
-    });
-    expect(store.decision).toBeNull();
-  });
-
-  it("refuses to integrate while the delegation pipeline is active", async () => {
-    const store = new FakeStore();
-    store.pipelineActiveMarker = {
-      pid: process.pid,
-      processToken: null,
-      startedAt: "2026-07-18T12:00:00.000Z",
-      sliced: false,
-    };
     store.decision = { decision: "accepted", recordedAt: "2026-07-18T12:01:00.000Z" };
-    const deps = dependencies(store);
+    let held = false;
+    let acquireCalls = 0;
+    let releaseCalls = 0;
+    const checkoutLock: CheckoutLock = {
+      key: "handler-integration-lock",
+      repositoryIdentity: "/canonical/repo/.git",
+      async release() {
+        expect(held).toBe(true);
+        releaseCalls += 1;
+        held = false;
+      },
+    };
+    let ps: PlatformServices;
+    ps = {
+      ...fakePlatform(),
+      async acquireCheckoutLock() {
+        acquireCalls += 1;
+        held = true;
+        return checkoutLock;
+      },
+    } as PlatformServices;
+    const deps = dependencies(store, ps);
     let integrationCalls = 0;
-    deps.applyCandidateTree = async () => {
+    deps.applyCandidateTree = async args => {
       integrationCalls += 1;
+      expect(held).toBe(true);
+      expect(args.borrowedCheckoutLock).toBe(checkoutLock);
+      expect(args.platformServices).toBe(ps);
       return { integration: "applied", detail: "candidate tree applied" };
     };
 
-    await expect(handleIntegrateCandidate(
+    await expect(invokeLifecycle("integrate", "/canonical/repo", deps)).resolves.toEqual({
+      integration: "applied",
+      detail: "candidate tree applied",
+    });
+    expect(acquireCalls).toBe(1);
+    expect(releaseCalls).toBe(1);
+    expect(integrationCalls).toBe(1);
+    expect(held).toBe(false);
+  });
+
+  it.each(["review", "decide", "integrate"] as const)(
+    "refuses to %s an active pipeline while holding the checkout lease",
+    async operation => {
+      const store = new FakeStore();
+      store.pipelineActiveMarker = {
+        pid: process.pid,
+        processToken: null,
+        startedAt: "2026-07-18T12:00:00.000Z",
+        sliced: true,
+      };
+      if (operation === "integrate") {
+        store.decision = { decision: "accepted", recordedAt: "2026-07-18T12:01:00.000Z" };
+      }
+      let held = false;
+      let acquireCalls = 0;
+      let releaseCalls = 0;
+      let markerReads = 0;
+      const ps = {
+        ...fakePlatform(),
+        acquireCheckoutLock: async (): Promise<CheckoutLock> => {
+          acquireCalls += 1;
+          held = true;
+          return {
+            key: "active-pipeline-lock",
+            repositoryIdentity: "/canonical/repo/.git",
+            async release() {
+              expect(held).toBe(true);
+              releaseCalls += 1;
+              held = false;
+            },
+          };
+        },
+      } as PlatformServices;
+      store.readPipelineActiveMarker = async () => {
+        markerReads += 1;
+        expect(held).toBe(true);
+        return store.pipelineActiveMarker;
+      };
+      const deps = dependencies(store, ps);
+      let gitCalls = 0;
+      let integrationCalls = 0;
+      const originalGit = deps.git!;
+      deps.git = async (cwd, args, indexFile) => {
+        gitCalls += 1;
+        return originalGit(cwd, args, indexFile);
+      };
+      deps.applyCandidateTree = async () => {
+        integrationCalls += 1;
+        return { integration: "applied", detail: "candidate tree applied" };
+      };
+
+      await expect(invokeLifecycle(operation, "/canonical/repo", deps)).resolves.toEqual({
+        ok: false,
+        error: "pipeline-active",
+        diagnostic: "the delegation pipeline for this run is still active",
+      });
+      expect.soft(acquireCalls).toBe(1);
+      expect.soft(releaseCalls).toBe(1);
+      expect.soft(markerReads).toBe(1);
+      expect.soft(gitCalls).toBe(0);
+      expect.soft(integrationCalls).toBe(0);
+      expect.soft(held).toBe(false);
+      if (operation === "decide") expect.soft(store.decision).toBeNull();
+    },
+  );
+
+  it.each(["review", "decide"] as const)(
+    "reports %s checkout lease release failure after the action completes",
+    async operation => {
+      let releaseCalls = 0;
+      const ps = {
+        ...fakePlatform(),
+        acquireCheckoutLock: async (): Promise<CheckoutLock> => ({
+          key: "release-failure-lock",
+          repositoryIdentity: "/canonical/repo/.git",
+          async release() {
+            releaseCalls += 1;
+            throw new Error("lifecycle checkout release failed");
+          },
+        }),
+      } as PlatformServices;
+
+      await expect(invokeLifecycle(
+        operation,
+        "/canonical/repo",
+        dependencies(new FakeStore(), ps),
+      )).resolves.toEqual({
+        ok: false,
+        error: "runtime-error",
+        diagnostic: "lifecycle checkout release failed",
+      });
+      expect(releaseCalls).toBe(1);
+    },
+  );
+
+  it("preserves an applied integration result when lifecycle lease release fails", async () => {
+    const store = new FakeStore();
+    store.decision = { decision: "accepted", recordedAt: "2026-07-18T12:01:00.000Z" };
+    let releaseCalls = 0;
+    const ps = {
+      ...fakePlatform(),
+      acquireCheckoutLock: async (): Promise<CheckoutLock> => ({
+        key: "integration-release-failure-lock",
+        repositoryIdentity: "/canonical/repo/.git",
+        async release() {
+          releaseCalls += 1;
+          throw new Error("lifecycle checkout release failed");
+        },
+      }),
+    } as PlatformServices;
+
+    await expect(invokeLifecycle(
+      "integrate",
+      "/canonical/repo",
+      dependencies(store, ps),
+    )).resolves.toEqual({
+      integration: "applied",
+      detail: "candidate tree applied; checkout lock release failed",
+    });
+    expect(releaseCalls).toBe(1);
+  });
+
+  it("preserves the primary lifecycle classification when lease release also fails", async () => {
+    let acquireCalls = 0;
+    let releaseCalls = 0;
+    const ps = {
+      ...fakePlatform(),
+      acquireCheckoutLock: async (): Promise<CheckoutLock> => {
+        acquireCalls += 1;
+        return {
+          key: "primary-and-release-failure-lock",
+          repositoryIdentity: "/canonical/repo/.git",
+          async release() {
+            releaseCalls += 1;
+            throw new Error("lifecycle checkout release failed");
+          },
+        };
+      },
+    } as PlatformServices;
+    const deps = dependencies(new FakeStore(), ps);
+    deps.git = async () => gitResult("unexpected-object\n");
+
+    await expect(handleReviewCandidate(
       "/canonical/repo",
       "run-tools",
-      candidate.manifestHash,
       deps,
     )).resolves.toEqual({
       ok: false,
-      error: "pipeline-active",
-      diagnostic: "the delegation pipeline for this run is still active",
+      error: "candidate-anchor-mismatch",
+      diagnostic: "candidate anchor no longer matches the archive; checkout lock release failed",
     });
-    expect(integrationCalls).toBe(0);
+    expect(acquireCalls).toBe(1);
+    expect(releaseCalls).toBe(1);
   });
 
   it("deletes the exact candidate anchor after recording rejection", async () => {

--- a/tests/runtime/tools.test.ts
+++ b/tests/runtime/tools.test.ts
@@ -684,6 +684,7 @@ describe("MCP tool handlers", () => {
       pid: process.pid,
       processToken: null,
       startedAt: "2026-07-18T12:00:00.000Z",
+      sliced: true,
     };
 
     await expect(handleDecideCandidate(
@@ -705,6 +706,7 @@ describe("MCP tool handlers", () => {
       pid: process.pid,
       processToken: null,
       startedAt: "2026-07-18T12:00:00.000Z",
+      sliced: false,
     };
     store.decision = { decision: "accepted", recordedAt: "2026-07-18T12:01:00.000Z" };
     const deps = dependencies(store);

--- a/tests/runtime/tools.test.ts
+++ b/tests/runtime/tools.test.ts
@@ -16,6 +16,7 @@ import {
   type ToolArtifactStore,
   type ToolDependencies,
 } from "../../src/mcp/tools.js";
+import { withRepoLock } from "../../src/mcp/serialize.js";
 import type { PipelineResult } from "../../src/pipeline/pipeline-runtime.js";
 import type { PlatformServices } from "../../src/platform/platform-services.js";
 import { getPlatformServices } from "../../src/platform/select-platform.js";
@@ -77,6 +78,14 @@ const result: AttemptResult = {
   producerModel: null,
   durationMs: 1,
   sessionId: null,
+};
+
+const failedSlicedResult: AttemptResult = {
+  ...result,
+  status: "failed",
+  failure: "producer-failure",
+  summary: "sliced pipeline failed",
+  candidate: null,
 };
 
 const pipelineResult: PipelineResult = {
@@ -142,8 +151,8 @@ class FakeStore implements ToolArtifactStore {
   pipelineActiveMarker: PipelineActiveMarker | null = null;
 
   constructor(
-    private readonly storedResult: AttemptResult = result,
-    private readonly storedManifest: RunManifest = manifest,
+    public storedResult: AttemptResult = result,
+    public storedManifest: RunManifest = manifest,
   ) {}
 
   async readResult(_runId: string): Promise<AttemptResult | null> {
@@ -187,6 +196,26 @@ function fakePlatform(): PlatformServices {
       release: async () => {},
     }),
   } as PlatformServices;
+}
+
+async function holdRepoLock(key: string): Promise<() => Promise<void>> {
+  let markHeld!: () => void;
+  let allowRelease!: () => void;
+  const held = new Promise<void>(resolve => { markHeld = resolve; });
+  const releaseAllowed = new Promise<void>(resolve => { allowRelease = resolve; });
+  const pending = withRepoLock(key, async () => {
+    markHeld();
+    await releaseAllowed;
+  });
+  await held;
+  return async () => {
+    allowRelease();
+    await pending;
+  };
+}
+
+async function waitForLockQueue(): Promise<void> {
+  await new Promise<void>(resolve => setImmediate(resolve));
 }
 
 function gitResult(stdout = "", exitCode = 0): GitResult {
@@ -486,6 +515,117 @@ describe("MCP tool handlers", () => {
 
     await expect(git(repoA, ["rev-parse", archivedCandidate.anchorRef])).resolves.toBe(commitOid);
     expect(store.decision).toBeNull();
+  });
+
+  it.each(["review", "decide", "integrate"] as const)(
+    "reloads the archive after a queued %s lifecycle request acquires the repository lock",
+    async operation => {
+      const store = new FakeStore();
+      if (operation === "integrate") {
+        store.decision = { decision: "accepted", recordedAt: "2026-07-19T00:00:00.000Z" };
+      }
+      let markCallerCanonicalized!: () => void;
+      const callerCanonicalized = new Promise<void>(resolve => {
+        markCallerCanonicalized = resolve;
+      });
+      const basePlatform = fakePlatform();
+      const ps = {
+        ...basePlatform,
+        canonicalizePath: async (input: string) => {
+          const canonical = await basePlatform.canonicalizePath(input);
+          if (input === "/supplied/repo") markCallerCanonicalized();
+          return canonical;
+        },
+      } as PlatformServices;
+      const deps = dependencies(store, ps);
+      let gitCalls = 0;
+      let integrationCalls = 0;
+      const originalGit = deps.git!;
+      deps.git = async (cwd, args, indexFile) => {
+        gitCalls += 1;
+        return originalGit(cwd, args, indexFile);
+      };
+      deps.applyCandidateTree = async () => {
+        integrationCalls += 1;
+        return { integration: "applied", detail: "candidate tree applied" };
+      };
+      const releaseLock = await holdRepoLock("/canonical/repo/.git");
+      const pending = operation === "review"
+        ? handleReviewCandidate("/supplied/repo", "run-tools", deps)
+        : operation === "decide"
+          ? handleDecideCandidate("/supplied/repo", "run-tools", "accepted", deps)
+          : handleIntegrateCandidate(
+            "/supplied/repo",
+            "run-tools",
+            candidate.manifestHash,
+            deps,
+          );
+
+      await callerCanonicalized;
+      await waitForLockQueue();
+      store.storedResult = failedSlicedResult;
+      await releaseLock();
+
+      await expect(pending).resolves.toEqual(operation === "review"
+        ? {
+          ok: false,
+          error: "candidate-not-found",
+          diagnostic: "archived run has no candidate",
+        }
+        : {
+          ok: false,
+          error: "candidate-not-verified",
+          diagnostic: "candidate did not complete independent verification",
+        });
+      expect(gitCalls).toBe(0);
+      expect(integrationCalls).toBe(0);
+      if (operation === "decide") expect(store.decision).toBeNull();
+    },
+  );
+
+  it("rejects an archived repository identity that changes before the queued archive load", async () => {
+    const repoA = "/canonical/repo-a";
+    const repoB = "/canonical/repo-b";
+    const callerPath = "/supplied/repo-a";
+    const store = new FakeStore(result, { ...manifest, repoRoot: repoA });
+    let markCallerCanonicalized!: () => void;
+    const callerCanonicalized = new Promise<void>(resolve => {
+      markCallerCanonicalized = resolve;
+    });
+    const ps = {
+      ...fakePlatform(),
+      canonicalizePath: async (input: string) => {
+        if (input === callerPath) {
+          markCallerCanonicalized();
+          return { input, canonical: repoA, gitCommonDir: `${repoA}/.git` };
+        }
+        if (input === repoA || input === repoB) {
+          return { input, canonical: input, gitCommonDir: `${input}/.git` };
+        }
+        throw new Error(`unexpected path: ${input}`);
+      },
+    } as PlatformServices;
+    const deps = dependencies(store, ps);
+    let gitCalls = 0;
+    const originalGit = deps.git!;
+    deps.git = async (cwd, args, indexFile) => {
+      gitCalls += 1;
+      return originalGit(cwd, args, indexFile);
+    };
+    const releaseLock = await holdRepoLock(`${repoA}/.git`);
+    const pending = handleReviewCandidate(callerPath, "run-tools", deps);
+
+    await callerCanonicalized;
+    await waitForLockQueue();
+    store.storedManifest = { ...manifest, repoRoot: repoB };
+    await releaseLock();
+
+    await expect(pending).resolves.toEqual({
+      ok: false,
+      error: "run-checkout-mismatch",
+      diagnostic: "candidate run belongs to a different repository than the supplied checkoutPath",
+    });
+    expect(gitCalls).toBe(0);
   });
 
   it("holds the checkout file lock while recording a decision and releases it afterwards", async () => {

--- a/tests/runtime/tools.test.ts
+++ b/tests/runtime/tools.test.ts
@@ -335,6 +335,32 @@ describe("handleDelegatePipeline", () => {
 
     expect(output).toEqual({ ok: true, result: pipelineResult });
   });
+
+  it("passes a sliced spec through validation to the pipeline unstripped", async () => {
+    const slicedSpec: DelegationSpec = {
+      ...validSpec,
+      slices: [{
+        objective: "slice one",
+        context: "test",
+        writeAllowlist: ["src/**"],
+        forbiddenScope: [],
+        successCriteria: ["tests pass"],
+        verification: validSpec.verification,
+      }],
+    };
+    const deps = dependencies();
+    let seenSlices: unknown;
+    deps.runPipeline = async (_checkout, spec) => {
+      seenSlices = (spec as DelegationSpec).slices;
+      return pipelineResult;
+    };
+
+    const output = await handleDelegatePipeline("/repo", slicedSpec, deps);
+
+    expect(output).toMatchObject({ ok: true });
+    expect(Array.isArray(seenSlices)).toBe(true);
+    expect((seenSlices as Array<{ objective: string }>)[0]).toMatchObject({ objective: "slice one" });
+  });
 });
 
 describe("MCP tool handlers", () => {

--- a/tests/runtime/tools.test.ts
+++ b/tests/runtime/tools.test.ts
@@ -85,6 +85,8 @@ const pipelineResult: PipelineResult = {
   attempt: result,
   rounds: [],
   increments: [],
+  slices: [],
+  haltedSliceIndex: null,
   verification: null,
   gate: {
     decisionReady: true,

--- a/tests/runtime/windows-platform.test.ts
+++ b/tests/runtime/windows-platform.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { acquireWxFileLock } from "../../src/platform/posix-platform-services.js";
 import {
@@ -42,6 +42,27 @@ describe("acquireWxFileLock (shared, all OSes)", () => {
     await first.release();
     const second = await acquireWxFileLock(key);
     await second.release();
+  });
+});
+
+describe("WindowsPlatformServices checkout lock contract", () => {
+  it("returns the canonical repository identity used to derive its lock key", async () => {
+    const repositoryIdentity = `C:\\repo\\.git-${randomUUID()}`;
+    const ps = Object.assign(new WindowsPlatformServices(), {
+      async canonicalizePath(input: string) {
+        return { input, canonical: "C:\\repo", gitCommonDir: repositoryIdentity };
+      },
+      async getProcessStartToken() { return null; },
+    });
+
+    const lock = await ps.acquireCheckoutLock("C:\\repo");
+
+    try {
+      expect(lock.repositoryIdentity).toBe(repositoryIdentity);
+      expect(lock.key).toBe(createHash("sha256").update(repositoryIdentity).digest("hex"));
+    } finally {
+      await lock.release();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Ships **sliced delegation** end-to-end: architect-authored, test-gated vertical `slices` on the delegation pipeline. Each slice runs fresh/no-context in an isolated worktree, gated by its own `verification`; a deterministic wayfinder routes advance/repair/halt from objective gate results (never model judgment or Producer self-report); review + advisor judge the composed candidate over the whole slice branch at the end.

Bumps marketplace/plugin version `0.20.0 → 0.21.0` and MCP wire `PROTOCOL_VERSION 1.2.0 → 1.3.0` (additive: `slices` + `haltedSliceIndex` on the pipeline output).

## Two decisions the reviewer must make before merge

This branch is **not** ready to auto-merge. Two things are genuinely the maintainer's call, not mechanical:

**1. `recovery-manager.ts` — architectural reconciliation (+394 / −99 vs `main`).**
This branch uses a **checkout-lease** abstraction for crash-recovery serialization; `main` independently evolved a **quarantine + in-lock-recheck** mechanism (ISO-B) for the *same* safety property. A merge forces a decision on **which mechanism wins** on a security-critical file. This cannot be resolved by whichever side the merge tool favors — it needs a deliberate design call.

**2. `0.21.0` version ownership.**
`main` has its own queued release also targeting `0.21.0` (different content). Two different `0.21.0`s cannot both exist, so this branch's version bump is **provisional** — whichever program lands second must re-bump. Decide which program owns `0.21.0` before tagging.

## Verification (all green on the branch head)

- `npx tsc --noEmit` — 0 errors
- `npx vitest run` — 862 passed / 12 skipped
- `bash scripts/validate-release.sh` — pass
- `claude plugin validate .` — pass
- Two independent fresh-context reviews of the security-sensitive halt-acceptance change — both PASS, zero blockers.

## Notable content

- **Partial-halt semantics fix:** a mid-run halt *after at least one slice has advanced* now yields `status: "human-decision-required"` with a real, human-acceptable promoted partial candidate (the advanced-slice branch), `haltedSliceIndex`, and per-slice routes — previously it returned `failed` with an unacceptable baseline candidate, contradicting the design. A halt on the *first* slice with nothing advanced stays `failed` (no partial branch to accept). Acceptance is gated on `status === "verified-candidate"`, independent of `verification.pass` by design — the human sees the honest evidence and decides.
- Reuses existing promote/verify/accept primitives — no new acceptance path introduced.

## Housekeeping note

`14902d3` ("frame delegated CLIs as subagents") is already on local `main` **and** on this branch as `7a817b2` (cherry-picked, author preserved). That duplication will surface at merge time — it is expected, not a mistake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sliced delegation pipelines with independently verified mini-spec steps, deterministic routing (advance/repair/halt), and mid-run halting that returns a partial candidate plus a halted-slice index.
  * Pipeline/delegation results now include per-slice routing metadata and halted-slice index.
  * Added guidance for surfacing delegations as Claude Code-style subagents, including dispatch/status formatting.
* **Bug Fixes**
  * Improved checkout lock/lease identity handling and more reliable lock-release behavior across delegation, integration, recovery, and pruning.
* **Documentation**
  * Updated README badge and changelog for the new sliced pipeline behavior and protocol bump.
* **Chores**
  * Bumped runtime and MCP protocol versions to **0.21.0 / 1.3.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->