### PR TITLE
fix(recovery): guard the cleanup journal with a cross-process mutex (0.22.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "claude-architect",
       "displayName": "Claude Architect",
       "source": "./",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "description": "Verified P0-A MCP delegation with macOS arm64 certified; Linux tested; native Windows pending. Codex edit eligibility requires its proven native sandbox.",
       "author": {
         "name": "elkaix",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-architect",
   "displayName": "Claude Architect",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Verified coding-agent delegation for Claude Code with isolated Producers, frozen candidate artifacts, independent review, and human-controlled integration.",
   "author": {
     "name": "Mohamed Elkholy",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to Claude Architect are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-19
+
+### Fixed
+
+- Crash-recovery cleanup journal: close a cross-process race where recovery's
+  torn-tail truncation could erase a cleanup intent a concurrent process had just
+  appended and fsynced. All journal appends (prune and recovery) and the torn-tail
+  repair now hold a new state-dir-scoped cross-process mutex
+  (`acquireCleanupJournalLock`), and recovery reads and repairs the journal as one
+  critical section under that mutex. The mutex is a leaf lock — never held while
+  acquiring the checkout lease or recovery lock, so ordering stays deadlock-free —
+  and is reclaimed like any other lock when its owner dies.
+
 ## [0.21.0] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-plugin-d97757?style=flat-square&labelColor=0b0e14">
   <img alt="OpenCode" src="https://img.shields.io/badge/OpenCode-native-58a6ff?style=flat-square&labelColor=0b0e14">
-  <img alt="version" src="https://img.shields.io/badge/version-0.21.0-9aa4b2?style=flat-square&labelColor=0b0e14">
+  <img alt="version" src="https://img.shields.io/badge/version-0.22.0-9aa4b2?style=flat-square&labelColor=0b0e14">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-3fb950?style=flat-square&labelColor=0b0e14">
 </p>
 

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -21930,7 +21930,7 @@ var StdioServerTransport = class {
 var PROTOCOL_VERSION = "1.3.0";
 var DELEGATION_SPEC_VERSION = "1";
 var ATTEMPT_RESULT_VERSION = "1";
-var RUNTIME_VERSION = "0.21.0";
+var RUNTIME_VERSION = "0.22.0";
 
 // src/platform/posix-platform-services.ts
 import { spawn, execFile } from "node:child_process";
@@ -22012,6 +22012,7 @@ var logger = {
 // src/platform/posix-platform-services.ts
 var LOCK_RETRY_MS = 30;
 var LOCK_TIMEOUT_MS = 2500;
+var CLEANUP_JOURNAL_LOCK_KEY = createHash("sha256").update("claude-architect:cleanup-journal:v1").digest("hex");
 function errorCode(error2) {
   return typeof error2 === "object" && error2 !== null && "code" in error2 ? String(error2.code) : void 0;
 }
@@ -22191,6 +22192,10 @@ var PosixPlatformServices = class {
     const ownerToken = await this.getProcessStartToken(nodeProcess2.pid);
     const lock = await acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
     return { ...lock, repositoryIdentity };
+  }
+  async acquireCleanupJournalLock() {
+    const ownerToken = await this.getProcessStartToken(nodeProcess2.pid);
+    return acquireWxFileLock(CLEANUP_JOURNAL_LOCK_KEY, "cleanup journal is locked", ownerToken);
   }
   async createSecureTempDirectory() {
     return fs.mkdtemp(path.join(tmpdir2(), "claude-architect-"));
@@ -22517,6 +22522,10 @@ var WindowsPlatformServices = class {
     const ownerToken = await this.getProcessStartToken(nodeProcess3.pid);
     const lock = await acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
     return { ...lock, repositoryIdentity };
+  }
+  async acquireCleanupJournalLock() {
+    const ownerToken = await this.getProcessStartToken(nodeProcess3.pid);
+    return acquireWxFileLock(CLEANUP_JOURNAL_LOCK_KEY, "cleanup journal is locked", ownerToken);
   }
   async createSecureTempDirectory() {
     return fs2.mkdtemp(path2.join(tmpdir3(), "claude-architect-"));
@@ -27271,29 +27280,34 @@ var ArtifactStore = class {
   }
   async appendCleanupRecord(record2) {
     await enqueueCleanupJournalWrite(async () => {
-      await this.ensureRunsRoot();
-      const runsRootIdentity = await ensurePlainDirectory(this.runsRoot);
-      const filename = path9.join(this.runsRoot, CLEANUP_JOURNAL);
-      const handle = await open3(
-        filename,
-        constants2.O_WRONLY | constants2.O_CREAT | constants2.O_APPEND | NO_FOLLOW,
-        384
-      );
+      const journalLock = await getPlatformServices().acquireCleanupJournalLock();
       try {
-        await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
-        const metadata = await handle.stat();
-        if (!metadata.isFile()) throw new RuntimeError("cleanup journal is not a regular file");
-        const line = `${serializeJson(record2)}
+        await this.ensureRunsRoot();
+        const runsRootIdentity = await ensurePlainDirectory(this.runsRoot);
+        const filename = path9.join(this.runsRoot, CLEANUP_JOURNAL);
+        const handle = await open3(
+          filename,
+          constants2.O_WRONLY | constants2.O_CREAT | constants2.O_APPEND | NO_FOLLOW,
+          384
+        );
+        try {
+          await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+          const metadata = await handle.stat();
+          if (!metadata.isFile()) throw new RuntimeError("cleanup journal is not a regular file");
+          const line = `${serializeJson(record2)}
 `;
-        await handle.writeFile(line, { encoding: "utf8" });
-        await handle.sync();
+          await handle.writeFile(line, { encoding: "utf8" });
+          await handle.sync();
+          await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+        } finally {
+          await handle.close();
+        }
+        await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+        await syncDirectory(this.runsRoot);
         await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
       } finally {
-        await handle.close();
+        await journalLock.release();
       }
-      await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
-      await syncDirectory(this.runsRoot);
-      await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
     });
   }
   async prune(policy, dependencies = {}) {
@@ -27733,6 +27747,7 @@ function withRunStartPidRecording(ps, context) {
     getProcessStartToken: (pid) => ps.getProcessStartToken(pid),
     terminateProcessTreeByPid: (pid, expectedToken) => ps.terminateProcessTreeByPid(pid, expectedToken),
     acquireCheckoutLock: (checkout) => ps.acquireCheckoutLock(checkout),
+    acquireCleanupJournalLock: () => ps.acquireCleanupJournalLock(),
     createSecureTempDirectory: () => ps.createSecureTempDirectory(),
     canonicalizePath: (input) => ps.canonicalizePath(input)
   };
@@ -31947,29 +31962,34 @@ async function createExactRef(repoRoot, ref, oid) {
   if (result.exitCode !== 0) throw runGitError("create recovery Git ref", result);
 }
 async function appendCleanupRecord(runsRoot, record2) {
-  const identity = await plainDirectoryIdentity(runsRoot);
-  if (identity === null) throw new RuntimeError("cleanup journal root disappeared");
-  const filename = path14.join(runsRoot, "cleanup.ndjson");
-  const handle = await open5(
-    filename,
-    constants4.O_WRONLY | constants4.O_CREAT | constants4.O_APPEND | NO_FOLLOW3,
-    384
-  );
+  const journalLock = await getPlatformServices().acquireCleanupJournalLock();
   try {
-    const metadata = await handle.stat();
-    const currentRoot2 = await lstat6(runsRoot);
-    if (!metadata.isFile() || !isPlainDirectory(currentRoot2) || !sameIdentity(currentRoot2, identity)) {
-      throw new RuntimeError("cleanup journal identity changed during recovery");
-    }
-    await handle.writeFile(`${JSON.stringify(record2)}
+    const identity = await plainDirectoryIdentity(runsRoot);
+    if (identity === null) throw new RuntimeError("cleanup journal root disappeared");
+    const filename = path14.join(runsRoot, "cleanup.ndjson");
+    const handle = await open5(
+      filename,
+      constants4.O_WRONLY | constants4.O_CREAT | constants4.O_APPEND | NO_FOLLOW3,
+      384
+    );
+    try {
+      const metadata = await handle.stat();
+      const currentRoot2 = await lstat6(runsRoot);
+      if (!metadata.isFile() || !isPlainDirectory(currentRoot2) || !sameIdentity(currentRoot2, identity)) {
+        throw new RuntimeError("cleanup journal identity changed during recovery");
+      }
+      await handle.writeFile(`${JSON.stringify(record2)}
 `, "utf8");
-    await handle.sync();
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    const currentRoot = await lstat6(runsRoot);
+    if (!isPlainDirectory(currentRoot) || !sameIdentity(currentRoot, identity)) {
+      throw new RuntimeError("cleanup journal root changed after recovery append");
+    }
   } finally {
-    await handle.close();
-  }
-  const currentRoot = await lstat6(runsRoot);
-  if (!isPlainDirectory(currentRoot) || !sameIdentity(currentRoot, identity)) {
-    throw new RuntimeError("cleanup journal root changed after recovery append");
+    await journalLock.release();
   }
 }
 async function reconcileCleanupRefs(record2, action) {
@@ -32066,8 +32086,15 @@ async function truncateCleanupTornTail(filename) {
   }
 }
 async function replayInterruptedPrunes(runsRoot, ps) {
-  const { pending, tornTail } = await readPendingCleanupRecords(runsRoot);
-  if (tornTail) await truncateCleanupTornTail(path14.join(runsRoot, "cleanup.ndjson"));
+  let pending;
+  const journalLock = await getPlatformServices().acquireCleanupJournalLock();
+  try {
+    const read = await readPendingCleanupRecords(runsRoot);
+    if (read.tornTail) await truncateCleanupTornTail(path14.join(runsRoot, "cleanup.ndjson"));
+    pending = read.pending;
+  } finally {
+    await journalLock.release();
+  }
   for (const record2 of [...pending.values()].sort((left, right) => left.runId.localeCompare(right.runId))) {
     if (record2.repoRoot === null) continue;
     const repoRoot = await validateRepositoryRoot(record2.repoRoot);

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -32717,7 +32717,14 @@ async function recoverStaleRuns(dependencies = {}) {
   try {
     const runsRoot = path14.join(root, "runs");
     const runsIdentity = await plainDirectoryIdentity(runsRoot);
-    if (runsIdentity !== null) await replayInterruptedPrunes(runsRoot, ps);
+    if (runsIdentity !== null) {
+      await reclaimDeadLock(
+        path14.join(locksRoot, `${CLEANUP_JOURNAL_LOCK_KEY}.lock`),
+        isProcessAlive,
+        (pid) => ps.getProcessStartToken(pid)
+      );
+      await replayInterruptedPrunes(runsRoot, ps);
+    }
     const journaledQuarantines = runsIdentity === null ? /* @__PURE__ */ new Set() : (await readRecoveryQuarantineJournal(runsRoot)).runIds;
     const stale = [];
     const recovered = [];

--- a/src/platform/platform-services.ts
+++ b/src/platform/platform-services.ts
@@ -34,10 +34,12 @@ export interface SupervisedExit {
   truncated: { stdout: boolean; stderr: boolean };
   spawnError?: unknown;             // set when the child emitted 'error' before start (→ spawn-failure)
 }
-export interface CheckoutLock {
+export interface FileLock {
   key: string;
-  readonly repositoryIdentity: string;
   release(): Promise<void>;
+}
+export interface CheckoutLock extends FileLock {
+  readonly repositoryIdentity: string;
 }
 export interface CanonicalPath { input: string; canonical: string; gitCommonDir: string | null; }
 
@@ -51,6 +53,13 @@ export interface PlatformServices {
   getProcessStartToken(pid: number): Promise<string | null>;
   terminateProcessTreeByPid(pid: number, expectedToken?: string | null): Promise<void>;   // crash recovery: kill a tree by recorded pid (no live SupervisedProcess). POSIX: kill(-pid); ESRCH treated as success.
   acquireCheckoutLock(checkout: string): Promise<CheckoutLock>;
+  /**
+   * Cross-process mutex over the shared cleanup journal (state-dir scoped, fixed
+   * key). All journal appends and the recovery torn-tail truncation acquire it so
+   * a truncation can never erase an intent a concurrent process appended+fsynced.
+   * A leaf lock: never held while acquiring another lock. Reclaimed like any lock.
+   */
+  acquireCleanupJournalLock(): Promise<FileLock>;
   createSecureTempDirectory(): Promise<string>;
   canonicalizePath(path: string): Promise<CanonicalPath>;
 }

--- a/src/platform/posix-platform-services.ts
+++ b/src/platform/posix-platform-services.ts
@@ -9,12 +9,18 @@ import { BoundedBuffer } from "../util/bounded-buffer.js";
 import { RuntimeError } from "../util/errors.js";
 import { logger } from "../util/logger.js";
 import type {
-  CanonicalPath, CheckoutLock, ExecutableRequest, PlatformServices, ResolvedExecutable,
+  CanonicalPath, CheckoutLock, ExecutableRequest, FileLock, PlatformServices, ResolvedExecutable,
   SpawnRequest, SupervisedExit, SupervisedProcess,
 } from "./platform-services.js";
 
 const LOCK_RETRY_MS = 30;
 const LOCK_TIMEOUT_MS = 2500;
+
+// Fixed 64-hex key for the state-dir-scoped cleanup-journal mutex. sha256 so it
+// matches the recovery lock-name pattern and is reclaimed like any dead lock, and
+// distinct (by domain prefix) from checkout locks keyed on a repository identity.
+export const CLEANUP_JOURNAL_LOCK_KEY =
+  createHash("sha256").update("claude-architect:cleanup-journal:v1").digest("hex");
 
 function errorCode(error: unknown): string | undefined {
   return typeof error === "object" && error !== null && "code" in error
@@ -186,6 +192,11 @@ export class PosixPlatformServices implements PlatformServices {
     const ownerToken = await this.getProcessStartToken(nodeProcess.pid);
     const lock = await acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
     return { ...lock, repositoryIdentity };
+  }
+
+  async acquireCleanupJournalLock(): Promise<FileLock> {
+    const ownerToken = await this.getProcessStartToken(nodeProcess.pid);
+    return acquireWxFileLock(CLEANUP_JOURNAL_LOCK_KEY, "cleanup journal is locked", ownerToken);
   }
 
   async createSecureTempDirectory(): Promise<string> {

--- a/src/platform/windows-platform-services.ts
+++ b/src/platform/windows-platform-services.ts
@@ -8,10 +8,10 @@ import { fileURLToPath } from "node:url";
 import { BoundedBuffer } from "../util/bounded-buffer.js";
 import { RuntimeError } from "../util/errors.js";
 import type {
-  CanonicalPath, CheckoutLock, ExecutableRequest, PlatformServices, ResolvedExecutable,
+  CanonicalPath, CheckoutLock, ExecutableRequest, FileLock, PlatformServices, ResolvedExecutable,
   SpawnRequest, SupervisedExit, SupervisedProcess,
 } from "./platform-services.js";
-import { acquireWxFileLock } from "./posix-platform-services.js";
+import { acquireWxFileLock, CLEANUP_JOURNAL_LOCK_KEY } from "./posix-platform-services.js";
 import { normalizeWindowsEnv } from "./windows-env.js";
 
 const childHandles = new WeakMap<SupervisedProcess, ChildProcess>();
@@ -310,6 +310,11 @@ export class WindowsPlatformServices implements PlatformServices {
     const ownerToken = await this.getProcessStartToken(nodeProcess.pid);
     const lock = await acquireWxFileLock(key, `checkout is locked: ${checkout}`, ownerToken);
     return { ...lock, repositoryIdentity };
+  }
+
+  async acquireCleanupJournalLock(): Promise<FileLock> {
+    const ownerToken = await this.getProcessStartToken(nodeProcess.pid);
+    return acquireWxFileLock(CLEANUP_JOURNAL_LOCK_KEY, "cleanup journal is locked", ownerToken);
   }
 
   async createSecureTempDirectory(): Promise<string> {

--- a/src/protocol/versions.ts
+++ b/src/protocol/versions.ts
@@ -1,4 +1,4 @@
 export const PROTOCOL_VERSION = "1.3.0" as const;      // MCP tool contract version
 export const DELEGATION_SPEC_VERSION = "1" as const;   // wire schema major
 export const ATTEMPT_RESULT_VERSION = "1" as const;
-export const RUNTIME_VERSION = "0.21.0" as const;       // mirrors plugin.json at release
+export const RUNTIME_VERSION = "0.22.0" as const;       // mirrors plugin.json at release

--- a/src/runtime/artifact-store.ts
+++ b/src/runtime/artifact-store.ts
@@ -1081,28 +1081,36 @@ export class ArtifactStore {
 
   private async appendCleanupRecord(record: CleanupRecord): Promise<void> {
     await enqueueCleanupJournalWrite(async () => {
-      await this.ensureRunsRoot();
-      const runsRootIdentity = await ensurePlainDirectory(this.runsRoot);
-      const filename = path.join(this.runsRoot, CLEANUP_JOURNAL);
-      const handle = await open(
-        filename,
-        constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | NO_FOLLOW,
-        0o600,
-      );
+      // Cross-process mutex over the shared journal: serializes this append against
+      // a concurrent process's append or recovery torn-tail truncation. Leaf lock —
+      // acquired and released here without holding any other lock across it.
+      const journalLock = await getPlatformServices().acquireCleanupJournalLock();
       try {
+        await this.ensureRunsRoot();
+        const runsRootIdentity = await ensurePlainDirectory(this.runsRoot);
+        const filename = path.join(this.runsRoot, CLEANUP_JOURNAL);
+        const handle = await open(
+          filename,
+          constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | NO_FOLLOW,
+          0o600,
+        );
+        try {
+          await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+          const metadata = await handle.stat();
+          if (!metadata.isFile()) throw new RuntimeError("cleanup journal is not a regular file");
+          const line = `${serializeJson(record)}\n`;
+          await handle.writeFile(line, { encoding: "utf8" });
+          await handle.sync();
+          await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+        } finally {
+          await handle.close();
+        }
         await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
-        const metadata = await handle.stat();
-        if (!metadata.isFile()) throw new RuntimeError("cleanup journal is not a regular file");
-        const line = `${serializeJson(record)}\n`;
-        await handle.writeFile(line, { encoding: "utf8" });
-        await handle.sync();
+        await syncDirectory(this.runsRoot);
         await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
       } finally {
-        await handle.close();
+        await journalLock.release();
       }
-      await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
-      await syncDirectory(this.runsRoot);
-      await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
     });
   }
 

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -15,6 +15,7 @@ import nodeProcess from "node:process";
 import { git, type GitResult } from "../git/git-exec.js";
 import { WorktreeManager } from "../git/worktree-manager.js";
 import type { PlatformServices } from "../platform/platform-services.js";
+import { CLEANUP_JOURNAL_LOCK_KEY } from "../platform/posix-platform-services.js";
 import { getPlatformServices } from "../platform/select-platform.js";
 import type { AttemptResult } from "../protocol/attempt-result.js";
 import { RuntimeError } from "../util/errors.js";
@@ -2010,7 +2011,19 @@ export async function recoverStaleRuns(
     const runsIdentity = await plainDirectoryIdentity(runsRoot);
     // The reconciler completes interrupted prunes under a per-repo checkout lease
     // rather than deferring them, so no run is skipped for a pending prune.
-    if (runsIdentity !== null) await replayInterruptedPrunes(runsRoot, ps);
+    if (runsIdentity !== null) {
+      // A crash can leave the cleanup-journal mutex held by a dead owner. That lock
+      // is a 64-hex leaf reclaimed by reclaimLocks() near the end of this body, but
+      // replayInterruptedPrunes acquires it first — so without an up-front reclaim a
+      // stale lock would make replay spin to its deadline and throw, aborting recovery
+      // before reclaimLocks ever runs and permanently blocking every future pass.
+      await reclaimDeadLock(
+        path.join(locksRoot, `${CLEANUP_JOURNAL_LOCK_KEY}.lock`),
+        isProcessAlive,
+        pid => ps.getProcessStartToken(pid),
+      );
+      await replayInterruptedPrunes(runsRoot, ps);
+    }
     const journaledQuarantines = runsIdentity === null
       ? new Set<string>()
       : (await readRecoveryQuarantineJournal(runsRoot)).runIds;

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -1076,28 +1076,35 @@ async function createExactRef(repoRoot: string, ref: string, oid: string): Promi
 }
 
 async function appendCleanupRecord(runsRoot: string, record: CleanupRecord): Promise<void> {
-  const identity = await plainDirectoryIdentity(runsRoot);
-  if (identity === null) throw new RuntimeError("cleanup journal root disappeared");
-  const filename = path.join(runsRoot, "cleanup.ndjson");
-  const handle = await open(
-    filename,
-    constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | NO_FOLLOW,
-    0o600,
-  );
+  // Same shared-journal mutex the prune writer holds: a completion/rollback append
+  // can never interleave with a concurrent intent append or a torn-tail truncation.
+  const journalLock = await getPlatformServices().acquireCleanupJournalLock();
   try {
-    const metadata = await handle.stat();
-    const currentRoot = await lstat(runsRoot);
-    if (!metadata.isFile() || !isPlainDirectory(currentRoot) || !sameIdentity(currentRoot, identity)) {
-      throw new RuntimeError("cleanup journal identity changed during recovery");
+    const identity = await plainDirectoryIdentity(runsRoot);
+    if (identity === null) throw new RuntimeError("cleanup journal root disappeared");
+    const filename = path.join(runsRoot, "cleanup.ndjson");
+    const handle = await open(
+      filename,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | NO_FOLLOW,
+      0o600,
+    );
+    try {
+      const metadata = await handle.stat();
+      const currentRoot = await lstat(runsRoot);
+      if (!metadata.isFile() || !isPlainDirectory(currentRoot) || !sameIdentity(currentRoot, identity)) {
+        throw new RuntimeError("cleanup journal identity changed during recovery");
+      }
+      await handle.writeFile(`${JSON.stringify(record)}\n`, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
     }
-    await handle.writeFile(`${JSON.stringify(record)}\n`, "utf8");
-    await handle.sync();
+    const currentRoot = await lstat(runsRoot);
+    if (!isPlainDirectory(currentRoot) || !sameIdentity(currentRoot, identity)) {
+      throw new RuntimeError("cleanup journal root changed after recovery append");
+    }
   } finally {
-    await handle.close();
-  }
-  const currentRoot = await lstat(runsRoot);
-  if (!isPlainDirectory(currentRoot) || !sameIdentity(currentRoot, identity)) {
-    throw new RuntimeError("cleanup journal root changed after recovery append");
+    await journalLock.release();
   }
 }
 
@@ -1228,8 +1235,18 @@ async function replayInterruptedPrunes(
   runsRoot: string,
   ps: Pick<PlatformServices, "acquireCheckoutLock">,
 ): Promise<void> {
-  const { pending, tornTail } = await readPendingCleanupRecords(runsRoot);
-  if (tornTail) await truncateCleanupTornTail(path.join(runsRoot, "cleanup.ndjson"));
+  // Read the journal and repair a torn tail as one critical section under the shared
+  // journal mutex, so no concurrent append can land between the read and the truncate
+  // (which would otherwise be erased). Completion appends below re-take the same lock.
+  let pending: Map<string, CleanupRecord>;
+  const journalLock = await getPlatformServices().acquireCleanupJournalLock();
+  try {
+    const read = await readPendingCleanupRecords(runsRoot);
+    if (read.tornTail) await truncateCleanupTornTail(path.join(runsRoot, "cleanup.ndjson"));
+    pending = read.pending;
+  } finally {
+    await journalLock.release();
+  }
   for (const record of [...pending.values()].sort((left, right) =>
     left.runId.localeCompare(right.runId))) {
     // A repoRoot-less legacy intent has neither anchor nor repository to lock.

--- a/src/runtime/run-start.ts
+++ b/src/runtime/run-start.ts
@@ -217,6 +217,7 @@ export function withRunStartPidRecording(
     terminateProcessTreeByPid: (pid, expectedToken) =>
       ps.terminateProcessTreeByPid(pid, expectedToken),
     acquireCheckoutLock: checkout => ps.acquireCheckoutLock(checkout),
+    acquireCleanupJournalLock: () => ps.acquireCleanupJournalLock(),
     createSecureTempDirectory: () => ps.createSecureTempDirectory(),
     canonicalizePath: input => ps.canonicalizePath(input),
   };

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -77,9 +77,9 @@ describe("P0-A plugin wiring", () => {
     const marketplace = JSON.parse(read(".claude-plugin/marketplace.json"));
     const readme = read("README.md");
     const changelog = read("CHANGELOG.md");
-    assert.equal(plugin.version, "0.21.0");
-    assert.equal(marketplace.plugins[0].version, "0.21.0");
-    assert.match(readme, /badge\/version-0\.21\.0-/u);
+    assert.equal(plugin.version, "0.22.0");
+    assert.equal(marketplace.plugins[0].version, "0.22.0");
+    assert.match(readme, /badge\/version-0\.22\.0-/u);
     assert.doesNotMatch(
       readme,
       /`\/delegate`/u,

--- a/tests/runtime/posix-platform-services.test.ts
+++ b/tests/runtime/posix-platform-services.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { PosixPlatformServices } from "../../src/platform/posix-platform-services.js";
+import { CLEANUP_JOURNAL_LOCK_KEY, PosixPlatformServices } from "../../src/platform/posix-platform-services.js";
 import { getPlatformServices } from "../../src/platform/select-platform.js";
 import { resolveStateDir } from "../../src/runtime/state-dir.js";
 import { scrubbedGitEnv } from "./helpers/git-fixture-env.js";
@@ -106,6 +106,28 @@ describe("PosixPlatformServices", () => {
     ]);
     expect(lockB.key).toBe(lockA.key);
     await lockB.release();
+  });
+
+  it("serializes the cleanup journal lock on a fixed key and frees it on release", async () => {
+    const lockA = await ps.acquireCleanupJournalLock();
+    expect(lockA.key).toBe(CLEANUP_JOURNAL_LOCK_KEY);
+    const lockPath = path.join(resolveStateDir(), "locks", `${lockA.key}.lock`);
+    await expect(fs.readFile(lockPath, "utf8").then(contents => JSON.parse(contents))).resolves.toEqual({
+      pid: process.pid,
+      processToken: await ps.getProcessStartToken(process.pid),
+    });
+    let resolved = false;
+    const pendingLockB = ps.acquireCleanupJournalLock().then(lock => { resolved = true; return lock; });
+    await delay(100);
+    expect(resolved).toBe(false);
+    await lockA.release();
+    const lockB = await Promise.race([
+      pendingLockB,
+      delay(1000).then(() => { throw new Error("second cleanup journal lock did not resolve after release"); }),
+    ]);
+    expect(lockB.key).toBe(CLEANUP_JOURNAL_LOCK_KEY);
+    await lockB.release();
+    await expect(fs.access(lockPath)).rejects.toThrow();
   });
 
   it("returns the canonical repository identity used to derive its lock key", async () => {

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { git } from "../../src/git/git-exec.js";
 import { WorktreeManager } from "../../src/git/worktree-manager.js";
 import { start } from "../../src/mcp/server.js";
+import { CLEANUP_JOURNAL_LOCK_KEY } from "../../src/platform/posix-platform-services.js";
 import { ArtifactStore } from "../../src/runtime/artifact-store.js";
 import { recoverStaleRuns } from "../../src/runtime/recovery-manager.js";
 import { buildRunManifest } from "../../src/runtime/run-manifest.js";
@@ -1862,6 +1863,66 @@ describe("recoverStaleRuns", () => {
       isProcessAlive: () => false,
     });
 
+    await expectMissing(quarantinePath);
+    expect((await git(repo.directory, ["rev-parse", "--verify", "--quiet", backupRef])).exitCode)
+      .not.toBe(0);
+    const records = (await readFile(path.join(runsRoot, "cleanup.ndjson"), "utf8"))
+      .trim().split("\n").map(line => JSON.parse(line) as { event: string });
+    expect(records.map(record => record.event)).toEqual([
+      "prune-cleanup-intent",
+      "prune-cleanup-complete",
+    ]);
+  });
+
+  it("reclaims a dead-owner cleanup journal lock before replaying an interrupted prune", async () => {
+    const repo = await initRepo();
+    const runId = "run-prune-journal-locked";
+    const anchorRef = `refs/claude-architect/candidates/${runId}`;
+    const backupRef = `refs/claude-architect/prune-backups/${runId}`;
+    const quarantineName = `.prune-${runId}-00000000-0000-4000-8000-000000000007`;
+    const runsRoot = path.join(process.env.CLAUDE_PLUGIN_DATA!, "runs");
+    const runDirectory = path.join(runsRoot, runId);
+    const quarantinePath = path.join(runsRoot, quarantineName);
+    await mkdir(runDirectory, { recursive: true });
+    await writeFile(path.join(runDirectory, "result.json"), "{}\n");
+    await runGit(repo.directory, ["update-ref", backupRef, repo.head]);
+    await rename(runDirectory, quarantinePath);
+    await writeFile(path.join(runsRoot, "cleanup.ndjson"), `${JSON.stringify({
+      event: "prune-cleanup-intent",
+      runId,
+      reason: "max-age",
+      anchorCleanup: "pending",
+      archiveBytes: 3,
+      quarantineName,
+      repoRoot: repo.directory,
+      anchorRef,
+      backupRef,
+      candidateCommitOid: repo.head,
+      recordedAt: "2026-07-14T12:00:00.000Z",
+    })}\n{"event":"prune-cleanup-com`);
+
+    // A previous process crashed while holding the cleanup-journal mutex, leaving its
+    // lock file behind with a now-dead owner. Recovery must reclaim it before replay:
+    // otherwise replayInterruptedPrunes spins to its acquire deadline, throws, and aborts
+    // recovery before reclaimLocks runs — permanently blocking every future pass. Without
+    // the up-front reclaim this test throws "cleanup journal is locked" after ~2.5s.
+    const journalLockPath = path.join(
+      process.env.CLAUDE_PLUGIN_DATA!, "locks", `${CLEANUP_JOURNAL_LOCK_KEY}.lock`,
+    );
+    await mkdir(path.dirname(journalLockPath), { recursive: true });
+    await writeFile(journalLockPath, JSON.stringify({ pid: 999_999, processToken: null }));
+
+    await recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    });
+
+    // The stale mutex is reclaimed and the prune it was blocking ran to completion.
+    await expectMissing(journalLockPath);
     await expectMissing(quarantinePath);
     expect((await git(repo.directory, ["rev-parse", "--verify", "--quiet", backupRef])).exitCode)
       .not.toBe(0);


### PR DESCRIPTION
## Summary

Closes the cross-process cleanup-journal race that an independent review of the 0.21.0 recovery reconciliation and CodeRabbit both flagged: recovery's torn-tail truncation could erase a cleanup intent a concurrent process had just appended and fsynced (worst case a leaked `prune-backup` ref — durability, not a trust break, but real).

## Fix

A new **state-dir-scoped cross-process file mutex**, `acquireCleanupJournalLock()`, keyed by a fixed `sha256` (so `reclaimLocks` reclaims it like any dead lock, and it never collides with repository-identity checkout locks). Every journal mutation now holds it:

- prune's `appendCleanupRecord` (artifact-store)
- recovery's completion/rollback `appendCleanupRecord`
- recovery's torn-tail `truncateCleanupTornTail`

and `replayInterruptedPrunes` **reads and repairs the journal as one critical section** under the mutex, so no concurrent append can land between the read and the truncate.

## Why it's deadlock-free

The journal mutex is a **leaf lock**: it is always acquired last and released before any other lock op. Ordering is invariant — `recovery.lock → checkout-lease → journal-mutex`, or `journal-mutex` alone. It is never held while acquiring the checkout lease or recovery lock. In-process writes remain serialized by the existing `enqueueCleanupJournalWrite` chain.

## Verification

- `npx tsc --noEmit` — 0
- `npx vitest run` — 889 passed / 12 skipped (+1: new mutual-exclusion + reclaim test for the mutex, runs on all platforms)
- `bash scripts/validate-release.sh` — pass
- `claude plugin validate .` — pass

Release **0.22.0** (PROTOCOL_VERSION unchanged — no wire change).

## Note

Branch name says "per-repo"; after investigation the per-repo-journal approach was rejected (null-`repoRoot` records have no repo/lease to key on, plus a format migration), and the maintainer chose the dedicated mutex. The code and this PR implement the mutex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash-recovery for the cleanup journal by serializing intent and completion/rollback writes across processes.
  * Prevented corruption/loss during torn-tail truncation repair by running repair reads/writes in one cross-process critical section.
  * Added deadlock reclaim during startup recovery for stale cleanup-journal mutexes.

* **Release**
  * Updated runtime, plugin, and marketplace versions to **0.22.0** and refreshed the README version badge.
  * Documented the **0.22.0** cleanup journal crash-recovery fix in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->