### PR TITLE
fix(recovery): converge cleanup when the delegating repository is deleted

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "claude-architect",
       "displayName": "Claude Architect",
       "source": "./",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "description": "Verified P0-A MCP delegation with macOS arm64 certified; Linux tested; native Windows pending. Codex edit eligibility requires its proven native sandbox.",
       "author": {
         "name": "elkaix",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-architect",
   "displayName": "Claude Architect",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Verified coding-agent delegation for Claude Code with isolated Producers, frozen candidate artifacts, independent review, and human-controlled integration.",
   "author": {
     "name": "Mohamed Elkholy",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to Claude Architect are recorded here. The format follows
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-19
+
+### Fixed
+
+- Cleanup convergence when a delegating repository is deleted. Previously a
+  vanished `repoRoot` made `canonicalizePath` throw: normal-path prune caught it
+  and retained the run forever (its bytes never reclaimed, so `maxBytes`/`maxAge`
+  could not converge), and — more seriously — a repo-gone *pending* cleanup intent
+  made `validateRepositoryRoot` throw outside the per-record guard in
+  `replayInterruptedPrunes`, aborting the entire crash-recovery pass on every run
+  (a permanent block). Both paths now reconcile a repository-absent run without
+  Git: prune reclaims the archive directly (no lease, no ref cleanup — the
+  candidate and backup refs died with the repository, and no live checkout can
+  integrate from a vanished repository), and recovery detects the absent
+  repository before validation and completes or rolls back the archive by disk
+  state, converging instead of aborting.
+
 ## [0.22.0] - 2026-07-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img alt="Claude Code" src="https://img.shields.io/badge/Claude_Code-plugin-d97757?style=flat-square&labelColor=0b0e14">
   <img alt="OpenCode" src="https://img.shields.io/badge/OpenCode-native-58a6ff?style=flat-square&labelColor=0b0e14">
-  <img alt="version" src="https://img.shields.io/badge/version-0.22.0-9aa4b2?style=flat-square&labelColor=0b0e14">
+  <img alt="version" src="https://img.shields.io/badge/version-0.23.0-9aa4b2?style=flat-square&labelColor=0b0e14">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-3fb950?style=flat-square&labelColor=0b0e14">
 </p>
 

--- a/docs/superpowers/plans/2026-07-18-sliced-delegation.md
+++ b/docs/superpowers/plans/2026-07-18-sliced-delegation.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** TypeScript (Node ESM, `.js` import specifiers), Ajv JSON Schema, Vitest, git worktrees via `WorktreeManager`.
 
-## STATUS (2026-07-18) — engine complete (T1–T5), T6–T8 pending
+## STATUS — T1–T8 complete; shipped in v0.21.0 (updated 2026-07-19)
 
 Built by dogfooding the delegate pipeline (Codex, high effort). Each task independently reviewed/verified; full Vitest suite green after each.
 
@@ -19,13 +19,13 @@ Built by dogfooding the delegate pipeline (Codex, high effort). Each task indepe
 | T3 Slice validation (allowlist-subset + cwd-escape) | ✅ done | `8bd267c` |
 | T4 Deterministic wayfinder `routeSlice` | ✅ done | `ac15a0f` |
 | T5 Pure git-free orchestrator `runSlicePhase` | ✅ done | `156df05` |
-| T6 Wire into `runPipeline` (real `runSlice` + partial-halt) | ⛔ blocked | — |
-| T7 MCP surface + protocol bump `1.2.0`→`1.3.0` | pending | — |
-| T8 Skill prose + docs + version sync | pending | — |
+| T6 Wire into `runPipeline` (real `runSlice` + partial-halt) | ✅ done | feat branch integration; B1 halt fix `78f0e86` |
+| T7 MCP surface + protocol bump `1.2.0`→`1.3.0` | ✅ done | `6e8b608` |
+| T8 Skill prose + docs + version sync | ✅ done | `1ae71c6` |
 
 **T5 was redesigned from the original plan below:** it is now a *pure, git-free* orchestrator taking an injected `runSlice(slice, index, base, attempt) => Promise<SliceAttempt>` callback and composing `routeSlice`; fully unit-tested. All git coupling moved to T6. See `src/pipeline/slice-runner.ts` for the real exported shape (`PipelineSlice`, `SliceAttempt`, `SlicePhaseDeps`, `SlicePhaseResult`, `runSlicePhase`).
 
-**T6 was blocked** by a concurrent session continuously editing the same `pipeline-runtime.ts` (guaranteed conflict) and leaving the shared checkout dirty. Resume when that file is stable.
+**T6 was temporarily blocked** by a concurrent session continuously editing the same `pipeline-runtime.ts` (guaranteed conflict) and leaving the shared checkout dirty. Resolved: sliced execution landed on the feat branch (`pipeline-runtime.ts` integration tests) and the partial-halt result contract was corrected in `78f0e86` (advance-then-halt → `human-decision-required` with a promoted verified partial). Shipped in v0.21.0.
 
 ### Corrected T6 design (supersedes the stale Task 6 section below)
 

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -32143,6 +32143,7 @@ async function truncateCleanupTornTail(filename) {
   }
 }
 async function repositoryRootExists(repoRoot) {
+  if (!path14.isAbsolute(repoRoot)) return true;
   try {
     await realpath6(repoRoot);
     return true;

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -21930,7 +21930,7 @@ var StdioServerTransport = class {
 var PROTOCOL_VERSION = "1.3.0";
 var DELEGATION_SPEC_VERSION = "1";
 var ATTEMPT_RESULT_VERSION = "1";
-var RUNTIME_VERSION = "0.22.0";
+var RUNTIME_VERSION = "0.23.0";
 
 // src/platform/posix-platform-services.ts
 import { spawn, execFile } from "node:child_process";
@@ -27310,6 +27310,48 @@ var ArtifactStore = class {
       }
     });
   }
+  // Reclaim a run whose delegating repository has been deleted. The intent is written
+  // before the archive is moved so a crash mid-removal is recoverable: recovery's
+  // repo-absent path finds the pending intent, sees the repository gone, and finishes the
+  // quarantine removal. No anchor fields are recorded — the repository's refs are gone, so
+  // recovery reconciles by disk state alone.
+  async reclaimRepoAbsentArchive(entry, reason, quarantineName, quarantinePath, repoRoot) {
+    await this.appendCleanupRecord({
+      event: "prune-cleanup-intent",
+      runId: entry.runId,
+      reason,
+      anchorCleanup: "pending",
+      archiveBytes: entry.bytes,
+      quarantineName,
+      repoRoot,
+      anchorRef: null,
+      backupRef: null,
+      candidateCommitOid: null,
+      recordedAt: (/* @__PURE__ */ new Date()).toISOString()
+    });
+    const runsRootIdentity = await ensurePlainDirectory(this.runsRoot);
+    await assertDirectoryIdentity(entry.directory, entry.identity);
+    await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+    await rename(entry.directory, quarantinePath);
+    await syncDirectory(this.runsRoot);
+    await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+    await assertDirectoryIdentity(quarantinePath, entry.identity);
+    await rm3(quarantinePath, { recursive: true, force: false });
+    await syncDirectory(this.runsRoot);
+    await this.appendCleanupRecord({
+      event: "prune-cleanup-complete",
+      runId: entry.runId,
+      reason,
+      anchorCleanup: "already-absent",
+      archiveBytes: entry.bytes,
+      quarantineName,
+      repoRoot,
+      anchorRef: null,
+      backupRef: null,
+      candidateCommitOid: null,
+      recordedAt: (/* @__PURE__ */ new Date()).toISOString()
+    });
+  }
   async prune(policy, dependencies = {}) {
     validatePruneLimit(policy.maxAgeMs, "maxAgeMs");
     validatePruneLimit(policy.maxBytes, "maxBytes");
@@ -27344,7 +27386,22 @@ var ArtifactStore = class {
           return;
         }
         const platformServices = dependencies.platformServices ?? getPlatformServices();
-        const canonical = await platformServices.canonicalizePath(initialManifest.repoRoot);
+        let canonical;
+        try {
+          canonical = await platformServices.canonicalizePath(initialManifest.repoRoot);
+        } catch (error2) {
+          if (errorCode2(error2) !== "ENOENT") throw error2;
+          await this.reclaimRepoAbsentArchive(
+            entry,
+            reason,
+            quarantineName,
+            quarantinePath,
+            initialManifest.repoRoot
+          );
+          removed.add(entry.runId);
+          retainedBytes -= entry.bytes;
+          return;
+        }
         const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
         lease = await platformServices.acquireCheckoutLock(canonical.canonical);
         if (lease.repositoryIdentity !== repositoryIdentity) {
@@ -32085,6 +32142,34 @@ async function truncateCleanupTornTail(filename) {
     await handle?.close();
   }
 }
+async function repositoryRootExists(repoRoot) {
+  try {
+    await realpath6(repoRoot);
+    return true;
+  } catch (error2) {
+    if (isMissing2(error2)) return false;
+    throw error2;
+  }
+}
+async function reconcileRepoAbsentPrune(runsRoot, record2) {
+  const runDirectory = path14.join(runsRoot, record2.runId);
+  const quarantinePath = path14.join(runsRoot, record2.quarantineName);
+  const runIdentity = await plainDirectoryIdentity(runDirectory);
+  const quarantineIdentity = await plainDirectoryIdentity(quarantinePath);
+  if (runIdentity !== null && quarantineIdentity !== null) {
+    throw new RuntimeError("both retained and quarantined run archives exist during recovery");
+  }
+  const action = runIdentity !== null ? "rollback" : "finish";
+  if (action === "finish" && quarantineIdentity !== null) {
+    await removePlainDirectory(quarantinePath, quarantineIdentity);
+  }
+  await appendCleanupRecord(runsRoot, {
+    ...record2,
+    event: action === "finish" ? "prune-cleanup-complete" : "prune-cleanup-rollback",
+    anchorCleanup: "already-absent",
+    recordedAt: (/* @__PURE__ */ new Date()).toISOString()
+  });
+}
 async function replayInterruptedPrunes(runsRoot, ps) {
   let pending;
   const journalLock = await getPlatformServices().acquireCleanupJournalLock();
@@ -32097,6 +32182,10 @@ async function replayInterruptedPrunes(runsRoot, ps) {
   }
   for (const record2 of [...pending.values()].sort((left, right) => left.runId.localeCompare(right.runId))) {
     if (record2.repoRoot === null) continue;
+    if (!await repositoryRootExists(record2.repoRoot)) {
+      await reconcileRepoAbsentPrune(runsRoot, record2);
+      continue;
+    }
     const repoRoot = await validateRepositoryRoot(record2.repoRoot);
     const commonResult = await git(repoRoot, [
       "rev-parse",

--- a/src/protocol/versions.ts
+++ b/src/protocol/versions.ts
@@ -1,4 +1,4 @@
 export const PROTOCOL_VERSION = "1.3.0" as const;      // MCP tool contract version
 export const DELEGATION_SPEC_VERSION = "1" as const;   // wire schema major
 export const ATTEMPT_RESULT_VERSION = "1" as const;
-export const RUNTIME_VERSION = "0.22.0" as const;       // mirrors plugin.json at release
+export const RUNTIME_VERSION = "0.23.0" as const;       // mirrors plugin.json at release

--- a/src/runtime/artifact-store.ts
+++ b/src/runtime/artifact-store.ts
@@ -1114,6 +1114,55 @@ export class ArtifactStore {
     });
   }
 
+  // Reclaim a run whose delegating repository has been deleted. The intent is written
+  // before the archive is moved so a crash mid-removal is recoverable: recovery's
+  // repo-absent path finds the pending intent, sees the repository gone, and finishes the
+  // quarantine removal. No anchor fields are recorded — the repository's refs are gone, so
+  // recovery reconciles by disk state alone.
+  private async reclaimRepoAbsentArchive(
+    entry: RunEntry,
+    reason: PruneReason,
+    quarantineName: string,
+    quarantinePath: string,
+    repoRoot: string,
+  ): Promise<void> {
+    await this.appendCleanupRecord({
+      event: "prune-cleanup-intent",
+      runId: entry.runId,
+      reason,
+      anchorCleanup: "pending",
+      archiveBytes: entry.bytes,
+      quarantineName,
+      repoRoot,
+      anchorRef: null,
+      backupRef: null,
+      candidateCommitOid: null,
+      recordedAt: new Date().toISOString(),
+    });
+    const runsRootIdentity = await ensurePlainDirectory(this.runsRoot);
+    await assertDirectoryIdentity(entry.directory, entry.identity);
+    await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+    await rename(entry.directory, quarantinePath);
+    await syncDirectory(this.runsRoot);
+    await assertDirectoryIdentity(this.runsRoot, runsRootIdentity);
+    await assertDirectoryIdentity(quarantinePath, entry.identity);
+    await rm(quarantinePath, { recursive: true, force: false });
+    await syncDirectory(this.runsRoot);
+    await this.appendCleanupRecord({
+      event: "prune-cleanup-complete",
+      runId: entry.runId,
+      reason,
+      anchorCleanup: "already-absent",
+      archiveBytes: entry.bytes,
+      quarantineName,
+      repoRoot,
+      anchorRef: null,
+      backupRef: null,
+      candidateCommitOid: null,
+      recordedAt: new Date().toISOString(),
+    });
+  }
+
   async prune(
     policy: PrunePolicy,
     dependencies: PruneDependencies = {},
@@ -1158,7 +1207,23 @@ export class ArtifactStore {
         // repository's checkout lease so recovery/integration cannot race a
         // prune that is deleting the same candidate anchors.
         const platformServices = dependencies.platformServices ?? getPlatformServices();
-        const canonical = await platformServices.canonicalizePath(initialManifest.repoRoot);
+        let canonical;
+        try {
+          canonical = await platformServices.canonicalizePath(initialManifest.repoRoot);
+        } catch (error) {
+          if (errorCode(error) !== "ENOENT") throw error;
+          // The repository this run was delegated from is gone. Its candidate/backup
+          // refs died with it and no live checkout can integrate from a vanished
+          // repository, so reclaim the archive directly — no lease, no Git — instead of
+          // retaining the run forever and blocking maxBytes/maxAge convergence. Any other
+          // canonicalization failure stays fail-closed (retained) via the outer catch.
+          await this.reclaimRepoAbsentArchive(
+            entry, reason, quarantineName, quarantinePath, initialManifest.repoRoot,
+          );
+          removed.add(entry.runId);
+          retainedBytes -= entry.bytes;
+          return;
+        }
         const repositoryIdentity = canonical.gitCommonDir ?? canonical.canonical;
         lease = await platformServices.acquireCheckoutLock(canonical.canonical);
         if (lease.repositoryIdentity !== repositoryIdentity) {

--- a/src/runtime/artifact-store.ts
+++ b/src/runtime/artifact-store.ts
@@ -1217,6 +1217,10 @@ export class ArtifactStore {
           // repository, so reclaim the archive directly — no lease, no Git — instead of
           // retaining the run forever and blocking maxBytes/maxAge convergence. Any other
           // canonicalization failure stays fail-closed (retained) via the outer catch.
+          // Tradeoff: a transiently-unmounted volume also reads as ENOENT, so a run on it
+          // may be reclaimed early. This is bounded — only maxAge/maxBytes-eligible runs
+          // reach here, and no Git runs, so the repository's refs survive a remount — and
+          // preferable to retaining unreclaimable runs forever.
           await this.reclaimRepoAbsentArchive(
             entry, reason, quarantineName, quarantinePath, initialManifest.repoRoot,
           );

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -1298,6 +1298,15 @@ async function replayInterruptedPrunes(
     // Reconcile its archive without Git and move on; otherwise validateRepositoryRoot
     // below throws and aborts the entire recovery pass — a permanent block, because
     // replayInterruptedPrunes runs before every other recovery step.
+    //
+    // The boundary is deliberately filesystem-definitive absence (realpath ENOENT), the
+    // expected "the user deleted their repo" lifecycle event. A repoRoot that still
+    // exists but is no longer the canonical repository (its .git removed, replaced by a
+    // file, moved so it is non-canonical, or a transient git error) is NOT treated as
+    // gone: it stays fail-closed through validateRepositoryRoot below, matching how every
+    // other anomalous cleanup record halts recovery for investigation. Widening this to
+    // "any validation failure" would fail open — a transient git hiccup would wrongly
+    // reclaim the archive and orphan a real repository's refs.
     if (!(await repositoryRootExists(record.repoRoot))) {
       await reconcileRepoAbsentPrune(runsRoot, record);
       continue;

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -1247,8 +1247,17 @@ async function repositoryRootExists(repoRoot: string): Promise<boolean> {
 // there is nothing to reconcile in Git; only the archive must converge. The checkout
 // lease is intentionally skipped: it serializes Git-ref reconciliation, and this path
 // performs none — a vanished repository cannot host a racing integration, and recovery
-// already holds the global recovery lock. The per-intent quarantine name is unique, so a
-// concurrent normal prune reclaiming the same run cannot collide on this archive.
+// already holds the global recovery lock.
+//
+// Limit of the lease-skip: the normal path's per-repo checkout lease also guarantees at
+// most one pending intent per run, so a shadowed quarantine can never be orphaned. This
+// path drops that lease, so IF prune were ever wired to run concurrently across processes
+// (it has no such caller today — the checkout lease is prune's only cross-process guard),
+// two repo-gone intents for one run could interleave and a crash after the losing rename
+// could strand a quarantine dir that no surviving pending intent references. That is a
+// disk-only leak, never a double-free (rename is atomic) or fail-open. Closing it needs a
+// recovery sweep of `.prune-*` dirs unmatched by any pending intent; do that before wiring
+// concurrent multi-process prune, not before.
 async function reconcileRepoAbsentPrune(
   runsRoot: string,
   record: CleanupRecord,

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -1232,6 +1232,48 @@ async function truncateCleanupTornTail(filename: string): Promise<void> {
   }
 }
 
+async function repositoryRootExists(repoRoot: string): Promise<boolean> {
+  try {
+    await realpath(repoRoot);
+    return true;
+  } catch (error) {
+    if (isMissing(error)) return false;
+    throw error;
+  }
+}
+
+// Complete an interrupted prune whose repository was deleted after the intent was
+// written. The candidate anchor and prune-backup refs died with the repository, so
+// there is nothing to reconcile in Git; only the archive must converge. The checkout
+// lease is intentionally skipped: it serializes Git-ref reconciliation, and this path
+// performs none — a vanished repository cannot host a racing integration, and recovery
+// already holds the global recovery lock. The per-intent quarantine name is unique, so a
+// concurrent normal prune reclaiming the same run cannot collide on this archive.
+async function reconcileRepoAbsentPrune(
+  runsRoot: string,
+  record: CleanupRecord,
+): Promise<void> {
+  const runDirectory = path.join(runsRoot, record.runId);
+  const quarantinePath = path.join(runsRoot, record.quarantineName);
+  const runIdentity = await plainDirectoryIdentity(runDirectory);
+  const quarantineIdentity = await plainDirectoryIdentity(quarantinePath);
+  if (runIdentity !== null && quarantineIdentity !== null) {
+    throw new RuntimeError("both retained and quarantined run archives exist during recovery");
+  }
+  // Same discriminator as the normal path: a retained run rolls back (nothing was
+  // removed), a quarantined run finishes (remove the archive that was moved aside).
+  const action = runIdentity !== null ? "rollback" : "finish";
+  if (action === "finish" && quarantineIdentity !== null) {
+    await removePlainDirectory(quarantinePath, quarantineIdentity);
+  }
+  await appendCleanupRecord(runsRoot, {
+    ...record,
+    event: action === "finish" ? "prune-cleanup-complete" : "prune-cleanup-rollback",
+    anchorCleanup: "already-absent",
+    recordedAt: new Date().toISOString(),
+  });
+}
+
 async function replayInterruptedPrunes(
   runsRoot: string,
   ps: Pick<PlatformServices, "acquireCheckoutLock">,
@@ -1252,6 +1294,14 @@ async function replayInterruptedPrunes(
     left.runId.localeCompare(right.runId))) {
     // A repoRoot-less legacy intent has neither anchor nor repository to lock.
     if (record.repoRoot === null) continue;
+    // A crash can strand a pending intent whose repository was deleted afterward.
+    // Reconcile its archive without Git and move on; otherwise validateRepositoryRoot
+    // below throws and aborts the entire recovery pass — a permanent block, because
+    // replayInterruptedPrunes runs before every other recovery step.
+    if (!(await repositoryRootExists(record.repoRoot))) {
+      await reconcileRepoAbsentPrune(runsRoot, record);
+      continue;
+    }
     // Serialize the archive/anchor reconciliation against the checkout
     // lifecycle: hold the repository's checkout lease exactly as prune did.
     const repoRoot = await validateRepositoryRoot(record.repoRoot);

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -1233,6 +1233,12 @@ async function truncateCleanupTornTail(filename: string): Promise<void> {
 }
 
 async function repositoryRootExists(repoRoot: string): Promise<boolean> {
+  // A non-absolute repoRoot is a malformed record, not a deleted repository: realpath
+  // would resolve it against the process CWD and could report a corrupt record as "gone",
+  // fail-open routing it into the repo-absent reconcile path. Report it present so it falls
+  // through to validateRepositoryRoot's absoluteness rejection and stays fail-closed,
+  // matching how every other anomalous cleanup record halts recovery for investigation.
+  if (!path.isAbsolute(repoRoot)) return true;
   try {
     await realpath(repoRoot);
     return true;

--- a/tests/runtime/artifact-store.test.ts
+++ b/tests/runtime/artifact-store.test.ts
@@ -1037,6 +1037,35 @@ describe("ArtifactStore", () => {
     });
   });
 
+  it("reclaims a run whose repository was deleted so pruning converges", async () => {
+    const runId = "run-repo-gone-prune";
+    const store = new ArtifactStore(runId);
+    const repoRoot = await writePrunableResult(store, runId, sampleResult(runId));
+    await utimes(store.runDirectory, new Date(0), new Date(0));
+
+    // The delegating repository is deleted, so canonicalizePath(repoRoot) throws ENOENT.
+    // Without the fix the run is retained forever and its bytes never reclaimed; with it
+    // the archive is reclaimed directly and a repo-absent intent/complete pair is journaled.
+    await rm(repoRoot, { recursive: true, force: true });
+
+    const result = await store.prune({ maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER });
+
+    expect(result.removed).toContain(runId);
+    await expect(stat(store.runDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+    const records = (await readFile(
+      join(process.env.CLAUDE_PLUGIN_DATA!, "runs", "cleanup.ndjson"),
+      "utf8",
+    )).trim().split("\n").map(line => JSON.parse(line) as {
+      event: string; repoRoot: string; anchorRef: string | null; anchorCleanup: string;
+    });
+    expect(records.map(record => record.event)).toEqual([
+      "prune-cleanup-intent",
+      "prune-cleanup-complete",
+    ]);
+    expect(records[0]).toMatchObject({ repoRoot, anchorRef: null, anchorCleanup: "pending" });
+    expect(records[1]).toMatchObject({ anchorRef: null, anchorCleanup: "already-absent" });
+  });
+
   it("surfaces a checkout lease release failure after a committed removal", async () => {
     const runId = "run-prune-release-failure";
     const store = new ArtifactStore(runId);

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -77,9 +77,9 @@ describe("P0-A plugin wiring", () => {
     const marketplace = JSON.parse(read(".claude-plugin/marketplace.json"));
     const readme = read("README.md");
     const changelog = read("CHANGELOG.md");
-    assert.equal(plugin.version, "0.22.0");
-    assert.equal(marketplace.plugins[0].version, "0.22.0");
-    assert.match(readme, /badge\/version-0\.22\.0-/u);
+    assert.equal(plugin.version, "0.23.0");
+    assert.equal(marketplace.plugins[0].version, "0.23.0");
+    assert.match(readme, /badge\/version-0\.23\.0-/u);
     assert.doesNotMatch(
       readme,
       /`\/delegate`/u,

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -1874,6 +1874,104 @@ describe("recoverStaleRuns", () => {
     ]);
   });
 
+  it("reclaims a repo-gone interrupted prune without aborting recovery", async () => {
+    const repo = await initRepo();
+    const runId = "run-prune-repo-gone-finish";
+    const anchorRef = `refs/claude-architect/candidates/${runId}`;
+    const backupRef = `refs/claude-architect/prune-backups/${runId}`;
+    const quarantineName = `.prune-${runId}-00000000-0000-4000-8000-000000000008`;
+    const runsRoot = path.join(process.env.CLAUDE_PLUGIN_DATA!, "runs");
+    const runDirectory = path.join(runsRoot, runId);
+    const quarantinePath = path.join(runsRoot, quarantineName);
+    await mkdir(runDirectory, { recursive: true });
+    await writeFile(path.join(runDirectory, "result.json"), "{}\n");
+    await rename(runDirectory, quarantinePath);
+    await writeFile(path.join(runsRoot, "cleanup.ndjson"), `${JSON.stringify({
+      event: "prune-cleanup-intent",
+      runId,
+      reason: "max-age",
+      anchorCleanup: "pending",
+      archiveBytes: 3,
+      quarantineName,
+      repoRoot: repo.directory,
+      anchorRef,
+      backupRef,
+      candidateCommitOid: repo.head,
+      recordedAt: "2026-07-14T12:00:00.000Z",
+    })}\n{"event":"prune-cleanup-com`);
+
+    // The repository this run was delegated from is deleted after the intent was
+    // written. Its anchor/backup refs are gone with it. Recovery must reconcile the
+    // quarantined archive without Git and converge — not throw in validateRepositoryRoot
+    // and abort the whole pass (a permanent block, since replay runs first every pass).
+    // Without the fix this test rejects with a realpath ENOENT before recovery completes.
+    await rm(repo.directory, { recursive: true, force: true });
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [], quarantined: [] });
+
+    await expectMissing(quarantinePath);
+    const records = (await readFile(path.join(runsRoot, "cleanup.ndjson"), "utf8"))
+      .trim().split("\n").map(line => JSON.parse(line) as { event: string });
+    expect(records.map(record => record.event)).toEqual([
+      "prune-cleanup-intent",
+      "prune-cleanup-complete",
+    ]);
+  });
+
+  it("rolls back a repo-gone interrupted prune whose archive is still retained", async () => {
+    const repo = await initRepo();
+    const runId = "run-prune-repo-gone-rollback";
+    const anchorRef = `refs/claude-architect/candidates/${runId}`;
+    const backupRef = `refs/claude-architect/prune-backups/${runId}`;
+    const quarantineName = `.prune-${runId}-00000000-0000-4000-8000-000000000009`;
+    const runsRoot = path.join(process.env.CLAUDE_PLUGIN_DATA!, "runs");
+    const runDirectory = path.join(runsRoot, runId);
+    await mkdir(runDirectory, { recursive: true });
+    await writeFile(path.join(runDirectory, "result.json"), "{}\n");
+    await writeFile(path.join(runsRoot, "cleanup.ndjson"), `${JSON.stringify({
+      event: "prune-cleanup-intent",
+      runId,
+      reason: "max-bytes",
+      anchorCleanup: "pending",
+      archiveBytes: 3,
+      quarantineName,
+      repoRoot: repo.directory,
+      anchorRef,
+      backupRef,
+      candidateCommitOid: repo.head,
+      recordedAt: "2026-07-14T12:00:00.000Z",
+    })}\n`);
+
+    // The archive is still retained (prune crashed before quarantining) and the repo
+    // then vanished. Recovery rolls the intent back without Git and leaves the archive
+    // for a later prune's repo-gone path to reclaim — never throwing.
+    await rm(repo.directory, { recursive: true, force: true });
+
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [], quarantined: [] });
+
+    await expect(access(path.join(runDirectory, "result.json"))).resolves.toBeUndefined();
+    const records = (await readFile(path.join(runsRoot, "cleanup.ndjson"), "utf8"))
+      .trim().split("\n").map(line => JSON.parse(line) as { event: string });
+    expect(records.map(record => record.event)).toEqual([
+      "prune-cleanup-intent",
+      "prune-cleanup-rollback",
+    ]);
+  });
+
   it("reclaims a dead-owner cleanup journal lock before replaying an interrupted prune", async () => {
     const repo = await initRepo();
     const runId = "run-prune-journal-locked";

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -1923,6 +1923,18 @@ describe("recoverStaleRuns", () => {
       "prune-cleanup-intent",
       "prune-cleanup-complete",
     ]);
+
+    // Recovery must be rerunnable: a second pass re-parses the repo-absent completion
+    // (non-null anchor fields + anchorCleanup "already-absent") and converges rather than
+    // rejecting the journal as malformed.
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [], quarantined: [] });
   });
 
   it("rolls back a repo-gone interrupted prune whose archive is still retained", async () => {
@@ -1970,6 +1982,16 @@ describe("recoverStaleRuns", () => {
       "prune-cleanup-intent",
       "prune-cleanup-rollback",
     ]);
+
+    // Rerunnable: a second pass re-parses the repo-absent rollback and converges.
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).resolves.toEqual({ recovered: [], quarantined: [] });
   });
 
   it("reclaims a dead-owner cleanup journal lock before replaying an interrupted prune", async () => {

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -1994,6 +1994,40 @@ describe("recoverStaleRuns", () => {
     })).resolves.toEqual({ recovered: [], quarantined: [] });
   });
 
+  it("fails closed on a malformed relative repoRoot instead of treating it as repo-gone", async () => {
+    const runId = "run-prune-relative-reporoot";
+    const quarantineName = `.prune-${runId}-00000000-0000-4000-8000-00000000000a`;
+    const runsRoot = path.join(process.env.CLAUDE_PLUGIN_DATA!, "runs");
+    await mkdir(path.join(runsRoot, runId), { recursive: true });
+    await writeFile(path.join(runsRoot, "cleanup.ndjson"), `${JSON.stringify({
+      event: "prune-cleanup-intent",
+      runId,
+      reason: "max-age",
+      anchorCleanup: "pending",
+      archiveBytes: 3,
+      quarantineName,
+      repoRoot: "relative/not-absolute/repo",
+      anchorRef: null,
+      backupRef: null,
+      candidateCommitOid: null,
+      recordedAt: "2026-07-14T12:00:00.000Z",
+    })}\n`);
+
+    // A relative repoRoot is a corrupted record, not a deleted repository. Recovery must
+    // fail closed (validateRepositoryRoot rejects a non-absolute root) rather than resolve
+    // it against the CWD and silently route it into the repo-absent reconcile path. Without
+    // the absoluteness guard, realpath resolves it against the CWD, reports absence, and
+    // recovery wrongly reconciles the run as repo-gone.
+    await expect(recoverStaleRuns({
+      platformServices: {
+        os: "darwin",
+        async getProcessStartToken() { return null; },
+        async terminateProcessTreeByPid() {},
+      },
+      isProcessAlive: () => false,
+    })).rejects.toThrow(/not absolute/i);
+  });
+
   it("reclaims a dead-owner cleanup journal lock before replaying an interrupted prune", async () => {
     const repo = await initRepo();
     const runId = "run-prune-journal-locked";


### PR DESCRIPTION
## Summary

Fixes cleanup convergence when the repository a run was delegated from is later deleted. A vanished `repoRoot` made `canonicalizePath` throw, with two consequences:

- **Normal-path prune** caught the throw and retained the run **forever** — its bytes were never reclaimed, so `maxBytes`/`maxAge` could not converge.
- **Recovery**: a repo-gone *pending* cleanup intent made `validateRepositoryRoot` throw **outside** the per-record guard in `replayInterruptedPrunes`, aborting the **entire** crash-recovery pass on every run. That is a **permanent block of all recovery** — the same class as the 0.22.0 journal-mutex deadlock.

## Fix

Both paths now reconcile a repository-absent run **without Git** (the candidate and prune-backup refs died with the repository, and no live checkout can integrate from a vanished repository):

- **Prune** — `reclaimRepoAbsentArchive`: write a repo-absent intent (null anchor fields) *before* moving the archive so a crash mid-removal is recoverable, then quarantine + remove. No lease, no ref cleanup. The lease-skip is justified by invariant: the path performs zero Git-ref operations, so it does not need the lock that serializes them.
- **Recovery** — `reconcileRepoAbsentPrune`: detect the absent repository (`repositoryRootExists`) *before* validation and reconcile the archive by disk state (finish → remove quarantine; rollback → leave a retained archive for a later prune). Converges instead of aborting.

## Tests (teeth-verified — fail without the fix)

- `artifact-store.test.ts`: "reclaims a run whose repository was deleted so pruning converges"
- `recovery-manager.test.ts`: "reclaims a repo-gone interrupted prune without aborting recovery" + "rolls back a repo-gone interrupted prune whose archive is still retained"

## Also

Doc sync: sliced-delegation plan STATUS table (T6–T8 shipped in v0.21.0); scratchpad backlog (0.22.0 torn-tail note marked resolved). Version `0.22.0` → `0.23.0`.

## Gates

tsc ✅ · vitest 893 ✅ / 12 skipped · validate-release ✅ · plugin validate ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash recovery and cleanup when a referenced repository has been deleted.
  * Pruning now safely removes archived runs whose repository is unavailable.
  * Recovery can complete or roll back interrupted cleanup without being blocked by missing repository data, and remains rerunnable.
* **Release**
  * Updated the application/plugin version to **0.23.0**.
* **Documentation**
  * Updated the changelog entry, README version badge, and the related plan status for **0.23.0**.
* **Tests**
  * Added coverage for “repo-gone” prune cleanup and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->