### PR TITLE
feat: prune the run archive at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Claude Architect are recorded here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- The MCP server now prunes the run archive once per boot, after crash
+  recovery. Terminal runs older than 14 days, or the oldest terminal runs once
+  the archive exceeds 1 GiB, are reclaimed; active, incomplete, and undecided
+  runs are always retained. A prune failure only logs a redacted diagnostic and
+  never blocks startup.
+
 ## [0.26.0] - 2026-07-19
 
 ### Changed

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -31,7 +31,7 @@ Verification commands run locally in a clean worktree. A command whose spec allo
 
 ## Retention and deletion
 
-The artifact store supports age/size pruning and crash-safe cleanup, but the plugin documentation does not promise a universal automatic retention period. Local evidence remains until pruning or user removal; Git candidate refs may keep objects reachable. Provider-side retention is controlled by the chosen model provider and account plan, not by Claude Architect.
+The artifact store applies age/size pruning with crash-safe cleanup. The MCP server prunes the run archive once at startup, after crash recovery: it reclaims terminal runs older than 14 days, and the oldest terminal runs once the archive exceeds 1 GiB, while always retaining active, incomplete, and undecided runs. This bounds unattended growth but does not promise an exact retention period — a single long-lived session is not pruned until its next startup, and Git candidate refs may keep objects reachable. Local evidence otherwise remains until the next prune or user removal. Provider-side retention is controlled by the chosen model provider and account plan, not by Claude Architect.
 
 To remove local data, first stop Claude Code and ensure no delegation is active. Uninstall/disable the plugin through Claude Code, remove its plugin data directory, and inspect/delete remaining `refs/claude-architect/candidates/*` if no audit or recovery need remains. Remove provider CLI caches, sessions, and credentials using each CLI's instructions. Deleting local data does not delete provider-side prompts, logs, or model-service records; use the provider's controls for those requests.
 

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -23728,6 +23728,15 @@ function redact(text) {
     current = next;
   }
 }
+function boundedRedactedDiagnostic(error2, maxBytes) {
+  const raw = error2 instanceof Error ? `${error2.name}: ${error2.message}` : String(error2);
+  const sanitized = redact(raw).replace(/\\\\[^'"\r\n]*/g, "[path]").replace(/[A-Za-z]:[\\/][^'"\r\n]*/g, "[path]").replace(/\\[^'"\r\n]*/g, "[path]").replace(/\/[^'"\r\n]*/g, "[path]");
+  const bytes = Buffer.from(sanitized, "utf8");
+  if (bytes.byteLength <= maxBytes) return sanitized;
+  let end = maxBytes;
+  while (end > 0 && (bytes[end] & 192) === 128) end -= 1;
+  return bytes.subarray(0, end).toString("utf8");
+}
 var DANGEROUS_KEYS = /* @__PURE__ */ new Set(["__proto__", "constructor", "prototype"]);
 function redactValue(value, redactKeys) {
   if (typeof value === "string") return redact(value);
@@ -31741,13 +31750,7 @@ function cleanupOutcome(record2) {
   return record2.backupRef === null ? "already-absent" : "deleted";
 }
 function boundedQuarantineReason(error2) {
-  const raw = error2 instanceof Error ? `${error2.name}: ${error2.message}` : String(error2);
-  const sanitized = redact(raw).replace(/\\\\[^'"\r\n]*/g, "[path]").replace(/[A-Za-z]:[\\/][^'"\r\n]*/g, "[path]").replace(/\\[^'"\r\n]*/g, "[path]").replace(/\/[^'"\r\n]*/g, "[path]");
-  const bytes = Buffer.from(sanitized, "utf8");
-  if (bytes.byteLength <= MAX_QUARANTINE_REASON_BYTES) return sanitized;
-  let end = MAX_QUARANTINE_REASON_BYTES;
-  while (end > 0 && (bytes[end] & 192) === 128) end -= 1;
-  return bytes.subarray(0, end).toString("utf8");
+  return boundedRedactedDiagnostic(error2, MAX_QUARANTINE_REASON_BYTES);
 }
 function parseRecoveryQuarantineRecord(line) {
   if (Buffer.byteLength(`${line}
@@ -33252,7 +33255,7 @@ async function start(dependencies = {}) {
   try {
     await (dependencies.pruneRuns ?? pruneRuns)();
   } catch (error2) {
-    console.error(`Claude Architect run pruning skipped: ${error2 instanceof Error ? error2.message : String(error2)}`);
+    console.error(`Claude Architect run pruning skipped: ${boundedRedactedDiagnostic(error2, 2e3)}`);
   }
   const server = new McpServer({ name: "claude-architect", version: RUNTIME_VERSION });
   server.registerTool(

--- a/runtime/server.mjs
+++ b/runtime/server.mjs
@@ -27577,6 +27577,13 @@ var ArtifactStore = class {
     return { removed: [...removed], retained };
   }
 };
+var DEFAULT_PRUNE_POLICY = {
+  maxAgeMs: 14 * 24 * 60 * 60 * 1e3,
+  maxBytes: 1024 * 1024 * 1024
+};
+async function pruneRuns(policy = DEFAULT_PRUNE_POLICY, dependencies = {}) {
+  return new ArtifactStore("prune-sweep").prune(policy, dependencies);
+}
 
 // src/runtime/reproducibility.ts
 import { readFile as readFile2 } from "node:fs/promises";
@@ -33242,6 +33249,11 @@ async function start(dependencies = {}) {
     return;
   }
   await (dependencies.recoverStaleRuns ?? recoverStaleRuns)();
+  try {
+    await (dependencies.pruneRuns ?? pruneRuns)();
+  } catch (error2) {
+    console.error(`Claude Architect run pruning skipped: ${error2 instanceof Error ? error2.message : String(error2)}`);
+  }
   const server = new McpServer({ name: "claude-architect", version: RUNTIME_VERSION });
   server.registerTool(
     "delegate",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import {
 } from "./tools.js";
 import { recoverStaleRuns } from "../runtime/recovery-manager.js";
 import { pruneRuns } from "../runtime/artifact-store.js";
+import { boundedRedactedDiagnostic } from "../runtime/redaction.js";
 
 const errorOutputFields = {
   ok: z.literal(false).optional(),
@@ -169,7 +170,7 @@ export async function start(dependencies: ServerDependencies = {}): Promise<void
   try {
     await (dependencies.pruneRuns ?? pruneRuns)();
   } catch (error) {
-    console.error(`Claude Architect run pruning skipped: ${error instanceof Error ? error.message : String(error)}`);
+    console.error(`Claude Architect run pruning skipped: ${boundedRedactedDiagnostic(error, 2_000)}`);
   }
 
   const server = new McpServer({ name: "claude-architect", version: RUNTIME_VERSION });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@ import {
   type ToolDependencies,
 } from "./tools.js";
 import { recoverStaleRuns } from "../runtime/recovery-manager.js";
+import { pruneRuns } from "../runtime/artifact-store.js";
 
 const errorOutputFields = {
   ok: z.literal(false).optional(),
@@ -139,6 +140,7 @@ export const integrateCandidateInputSchema = z.object({
 
 export type ServerDependencies = ToolDependencies & DoctorDependencies & GitReadDependencies & {
   recoverStaleRuns?: typeof recoverStaleRuns;
+  pruneRuns?: typeof pruneRuns;
 };
 
 function toolOutput(value: object) {
@@ -157,6 +159,18 @@ export async function start(dependencies: ServerDependencies = {}): Promise<void
   }
 
   await (dependencies.recoverStaleRuns ?? recoverStaleRuns)();
+
+  // Reclaim aged/oversized run archives once per boot, after recovery has
+  // settled interrupted prunes. Fail-safe: a prune failure (including a lease
+  // held by a concurrent session) must never block or crash startup, so it can
+  // only log. Bounded lease waits (2.5s each) match the recovery step that
+  // already runs under leases above. Startup-only pruning does not bound a
+  // single long-lived session; that is an accepted limitation.
+  try {
+    await (dependencies.pruneRuns ?? pruneRuns)();
+  } catch (error) {
+    console.error(`Claude Architect run pruning skipped: ${error instanceof Error ? error.message : String(error)}`);
+  }
 
   const server = new McpServer({ name: "claude-architect", version: RUNTIME_VERSION });
   server.registerTool(

--- a/src/runtime/artifact-store.ts
+++ b/src/runtime/artifact-store.ts
@@ -1384,3 +1384,30 @@ export class ArtifactStore {
     return { removed: [...removed], retained };
   }
 }
+
+/**
+ * Default retention for the startup run-archive sweep. Terminal runs older than
+ * ~14 days, or the oldest terminal runs once the archive exceeds ~1 GiB, are
+ * reclaimed. `prune()` always retains active, incomplete, and undecided runs
+ * regardless of these limits. These are deliberate constants, not configuration:
+ * they are the minimal fix for unbounded run-log growth, and the runtime has no
+ * env-override convention to follow.
+ */
+export const DEFAULT_PRUNE_POLICY: PrunePolicy = {
+  maxAgeMs: 14 * 24 * 60 * 60 * 1000,
+  maxBytes: 1024 * 1024 * 1024,
+};
+
+/**
+ * Prune the shared run archive across every run. `ArtifactStore.prune` reads the
+ * runs root and ignores its instance run id, so this thin wrapper expresses the
+ * cross-run intent without fabricating a per-run store at the call site. The
+ * `prune-sweep` id is inert: it names no real run and prune never reads or writes
+ * its run directory.
+ */
+export async function pruneRuns(
+  policy: PrunePolicy = DEFAULT_PRUNE_POLICY,
+  dependencies: PruneDependencies = {},
+): Promise<PruneResult> {
+  return new ArtifactStore("prune-sweep").prune(policy, dependencies);
+}

--- a/src/runtime/recovery-manager.ts
+++ b/src/runtime/recovery-manager.ts
@@ -21,7 +21,7 @@ import type { AttemptResult } from "../protocol/attempt-result.js";
 import { RuntimeError } from "../util/errors.js";
 import { logger } from "../util/logger.js";
 import { ArtifactStore } from "./artifact-store.js";
-import { redact } from "./redaction.js";
+import { boundedRedactedDiagnostic } from "./redaction.js";
 import { resolveStateDir } from "./state-dir.js";
 
 const NO_FOLLOW = constants.O_NOFOLLOW ?? 0;
@@ -587,17 +587,7 @@ function cleanupOutcome(record: CleanupRecord): AnchorCleanup {
 }
 
 function boundedQuarantineReason(error: unknown): string {
-  const raw = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-  const sanitized = redact(raw)
-    .replace(/\\\\[^'"\r\n]*/g, "[path]")
-    .replace(/[A-Za-z]:[\\/][^'"\r\n]*/g, "[path]")
-    .replace(/\\[^'"\r\n]*/g, "[path]")
-    .replace(/\/[^'"\r\n]*/g, "[path]");
-  const bytes = Buffer.from(sanitized, "utf8");
-  if (bytes.byteLength <= MAX_QUARANTINE_REASON_BYTES) return sanitized;
-  let end = MAX_QUARANTINE_REASON_BYTES;
-  while (end > 0 && (bytes[end]! & 0xc0) === 0x80) end -= 1;
-  return bytes.subarray(0, end).toString("utf8");
+  return boundedRedactedDiagnostic(error, MAX_QUARANTINE_REASON_BYTES);
 }
 
 function parseRecoveryQuarantineRecord(line: string): RecoveryQuarantineRecord {

--- a/src/runtime/redaction.ts
+++ b/src/runtime/redaction.ts
@@ -100,6 +100,26 @@ export function redact(text: string): string {
   }
 }
 
+/**
+ * Turn an arbitrary caught error into a stable diagnostic safe for bounded
+ * runtime logs: redact registered secrets and token shapes, replace absolute
+ * POSIX/Windows/UNC paths with `[path]` so filesystem and Git failures cannot
+ * leak repository locations, then truncate to `maxBytes` on a UTF-8 boundary.
+ */
+export function boundedRedactedDiagnostic(error: unknown, maxBytes: number): string {
+  const raw = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  const sanitized = redact(raw)
+    .replace(/\\\\[^'"\r\n]*/g, "[path]")
+    .replace(/[A-Za-z]:[\\/][^'"\r\n]*/g, "[path]")
+    .replace(/\\[^'"\r\n]*/g, "[path]")
+    .replace(/\/[^'"\r\n]*/g, "[path]");
+  const bytes = Buffer.from(sanitized, "utf8");
+  if (bytes.byteLength <= maxBytes) return sanitized;
+  let end = maxBytes;
+  while (end > 0 && (bytes[end]! & 0xc0) === 0x80) end -= 1;
+  return bytes.subarray(0, end).toString("utf8");
+}
+
 const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 function redactValue(value: unknown, redactKeys: boolean): unknown {

--- a/tests/runtime/artifact-store.test.ts
+++ b/tests/runtime/artifact-store.test.ts
@@ -21,7 +21,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AttemptResult } from "../../src/protocol/attempt-result.js";
-import { ArtifactStore } from "../../src/runtime/artifact-store.js";
+import { ArtifactStore, pruneRuns } from "../../src/runtime/artifact-store.js";
 import {
   buildRunManifest,
   sanitizeRunManifest,
@@ -879,6 +879,19 @@ describe("ArtifactStore", () => {
     const result = await oldStore.prune({ maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER });
 
     expect(result.removed).toContain("run-old");
+    await expect(stat(oldDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reclaims over-age runs through the cross-run pruneRuns wrapper", async () => {
+    const oldStore = new ArtifactStore("run-wrapper-old");
+    await writePrunableResult(oldStore, "run-wrapper-old", sampleResult("run-wrapper-old"));
+    const oldDirectory = join(process.env.CLAUDE_PLUGIN_DATA!, "runs", "run-wrapper-old");
+    const oldTime = new Date(Date.now() - 60_000);
+    await utimes(oldDirectory, oldTime, oldTime);
+
+    const result = await pruneRuns({ maxAgeMs: 1_000, maxBytes: Number.MAX_SAFE_INTEGER });
+
+    expect(result.removed).toContain("run-wrapper-old");
     await expect(stat(oldDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 

--- a/tests/runtime/recovery-manager.test.ts
+++ b/tests/runtime/recovery-manager.test.ts
@@ -2507,8 +2507,41 @@ describe("MCP startup recovery", () => {
         serverEvents.push("recover");
         return { recovered: [], quarantined: [] };
       },
+      async pruneRuns() {
+        return { removed: [], retained: [] };
+      },
     });
 
     expect(serverEvents).toEqual(["recover", "connect"]);
+  });
+
+  it("prunes run archives after recovery and before connecting", async () => {
+    await start({
+      async recoverStaleRuns() {
+        serverEvents.push("recover");
+        return { recovered: [], quarantined: [] };
+      },
+      async pruneRuns() {
+        serverEvents.push("prune");
+        return { removed: [], retained: [] };
+      },
+    });
+
+    expect(serverEvents).toEqual(["recover", "prune", "connect"]);
+  });
+
+  it("connects even when startup pruning fails", async () => {
+    await expect(start({
+      async recoverStaleRuns() {
+        serverEvents.push("recover");
+        return { recovered: [], quarantined: [] };
+      },
+      async pruneRuns() {
+        serverEvents.push("prune");
+        throw new Error("prune failed at startup");
+      },
+    })).resolves.toBeUndefined();
+
+    expect(serverEvents).toEqual(["recover", "prune", "connect"]);
   });
 });

--- a/tests/runtime/redaction.test.ts
+++ b/tests/runtime/redaction.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  boundedRedactedDiagnostic,
   clearRegisteredSecrets,
   redact,
   redactRecord,
@@ -137,5 +138,37 @@ describe("redact", () => {
     expect(JSON.stringify(output)).not.toContain("enterprise-secret-key");
     expect(JSON.stringify(output)).toContain("[s]");
     registration.dispose();
+  });
+});
+
+describe("boundedRedactedDiagnostic", () => {
+  it("strips POSIX and Windows repository paths from an error message", () => {
+    const posix = boundedRedactedDiagnostic(
+      new Error("ENOENT: no such file /Users/panda/Projects/secret-repo/.git/HEAD"),
+      2_000,
+    );
+    expect(posix).not.toContain("/Users/panda/Projects/secret-repo");
+    expect(posix).toContain("[path]");
+
+    const windows = boundedRedactedDiagnostic(
+      new Error("cannot open C:\\Users\\panda\\secret-repo\\.git"),
+      2_000,
+    );
+    expect(windows).not.toContain("secret-repo");
+    expect(windows).toContain("[path]");
+  });
+
+  it("redacts registered secrets and non-Error values", () => {
+    clearRegisteredSecrets();
+    const registration = registerSecretValue("enterprise-secret-key");
+    expect(boundedRedactedDiagnostic("failed with enterprise-secret-key", 2_000)).not.toContain(
+      "enterprise-secret-key",
+    );
+    registration.dispose();
+  });
+
+  it("truncates to the byte budget on a UTF-8 boundary", () => {
+    const output = boundedRedactedDiagnostic(new Error("x".repeat(5_000)), 100);
+    expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(100);
   });
 });


### PR DESCRIPTION
## Summary

`ArtifactStore.prune()` was fully implemented (crash-safe, lease-serialized, retains active/incomplete/undecided runs) but **never invoked**, so delegation run-log directories accumulated without bound — a week of dogfooding left 277 run dirs. This wires the existing pruner into MCP server startup.

- Add a cross-run `pruneRuns()` wrapper and `DEFAULT_PRUNE_POLICY` — retain terminal runs younger than 14 days, trim the oldest terminal runs once the archive exceeds 1 GiB; active, incomplete, and undecided runs are always retained by `prune()`.
- Invoke it in `start()` after `recoverStaleRuns()`, so it runs once per boot after recovery settles interrupted prunes. **Fail-safe:** a prune failure (including a checkout lease held by a concurrent session) can only log and never blocks or crashes startup. Injected as a `ServerDependency`, matching the existing recovery seam.
- Correct `docs/PRIVACY.md`: pruning now runs automatically at startup with documented limits; notes that a single long-lived session is bounded only at its next start.

Deliberate scope choices: hardcoded constants (no env-config — the runtime has no such convention), and startup-only pruning (bounded per-boot rather than per-run).

## Verification

- `npx tsc --noEmit` clean
- Vitest: 874 passed, 12 skipped — new tests: startup fires prune after recovery and before connect; startup survives a throwing prune; `pruneRuns` reclaims an over-age run
- `bash scripts/validate-release.sh` and `claude plugin validate` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic run-archive cleanup at server startup after crash recovery.
  * Older completed runs are removed after 14 days or when the archive exceeds 1 GiB.
  * Active, incomplete, and undecided runs are preserved.

* **Bug Fixes**
  * Cleanup failures no longer prevent the server from starting.

* **Documentation**
  * Clarified retention timing, Git reference behavior, and provider-side retention limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->