### PR TITLE
Add a direct Codex CLI skill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, ubuntu-latest, windows-latest]
+        os: [macos-15, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Claude Architect are recorded here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- `/claude-architect:codex`, a direct, unverified Codex CLI lane for running
+  `codex exec` against the user's checkout. The skill preserves the current
+  model and reasoning roster, sandbox and timeout guidance, follow-up flow,
+  critical-evaluation rules, and error handling from the authoritative
+  `skill-codex` design, while pointing users to
+  `/claude-architect:delegate` when they need isolated production, a frozen
+  Candidate Artifact, independent verification, and controlled integration.
+
 ## [0.41.0] - 2026-07-27
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@ All notable changes to Claude Architect are recorded here. The format follows
 
 - `/claude-architect:codex`, a direct, unverified Codex CLI lane for running
   `codex exec` against the user's checkout. The skill preserves the current
-  model and reasoning roster, sandbox and timeout guidance, follow-up flow,
-  critical-evaluation rules, and error handling from the authoritative
-  `skill-codex` design, while pointing users to
-  `/claude-architect:delegate` when they need isolated production, a frozen
+  model and reasoning roster, uses explicit sandbox modes, retains stderr
+  diagnostics, closes harness stdin across platforms, and points users to
+  `/claude-architect:delegate` when they need an isolated worktree, a frozen
   Candidate Artifact, independent verification, and controlled integration.
 
 ## [0.41.0] - 2026-07-27

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="#quick-start"><img alt="delegate skill" src="https://img.shields.io/badge/skill-delegate-e6edf3?style=flat-square&labelColor=0b0e14"></a>
+  <a href="#direct-codex-cli"><img alt="codex skill" src="https://img.shields.io/badge/skill-codex-e6edf3?style=flat-square&labelColor=0b0e14"></a>
 </p>
 
 <p align="center">
@@ -68,6 +69,16 @@ Open Claude Code in a Git repository and name the Producer you want:
 
 If no Producer is named, the skill asks you to choose Codex, OpenCode, Pi, or Pythinker. Pi, OpenCode, and Pythinker are harnesses that accept optional model and thinking/variant overrides; model selection within a harness lane is optional and otherwise defers to that CLI's configured default. For non-trivial work it uses the fresh-context review pipeline. Read the exact patch, findings, and verification output before deciding whether to accept.
 
+### Direct Codex CLI
+
+The direct, unverified Codex CLI lane runs `codex exec` against your current checkout without an isolated worktree, frozen Candidate Artifact, or independent verification:
+
+```text
+/claude-architect:codex Review this checkout with gpt-5.6-sol at high reasoning.
+```
+
+Use it for direct Codex assistance when those controls are not required. Use `/claude-architect:delegate` when changes need the verified lane and its isolated production, frozen evidence, independent verification, and guarded integration.
+
 ### Superpowers skill boundary
 
 Claude Architect can use host-side Superpowers skills such as brainstorming, writing plans, and executing plans to shape and coordinate a delegation. Producers do not inherit that host skill set. Each edit attempt is offered only the three task-scoped procedures compatible with the trust model:
@@ -98,6 +109,7 @@ What this does not relax: independent verification still decides what may be acc
 | Kind | Name | Purpose |
 |---|---|---|
 | Skill | `/claude-architect:delegate` | Builds a versioned spec and drives delegation, review, decision, and guarded integration. |
+| Skill | `/claude-architect:codex` | Runs Codex CLI directly against the current checkout without the verified delegation lifecycle. |
 | Skill | `/claude-architect:subagent-driven-delegation` | Executes a multi-task plan with the Superpowers subagent-driven-development loop, using a verified Producer as the implementer for every task. |
 | Agent | `advisor` | Current strictly read-only commitment-boundary advisor. |
 | MCP | `validateDelegationSpec` | Validates a spec without starting a Producer and returns its canonical correlation digest. |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The direct, unverified Codex CLI lane runs `codex exec` against your current che
 /claude-architect:codex Review this checkout with gpt-5.6-sol at high reasoning.
 ```
 
-Use it for direct Codex assistance when those controls are not required. Use `/claude-architect:delegate` when changes need the verified lane and its isolated production, frozen evidence, independent verification, and guarded integration.
+Use it for direct Codex assistance when those controls are not required. Use `/claude-architect:delegate` when changes need the verified lane and its isolated worktree, frozen evidence, independent verification, and guarded integration.
 
 ### Superpowers skill boundary
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The direct, unverified Codex CLI lane runs `codex exec` against your current che
 /claude-architect:codex Review this checkout with gpt-5.6-sol at high reasoning.
 ```
 
-Use it for direct Codex assistance when those controls are not required. Use `/claude-architect:delegate` when changes need the verified lane and its isolated worktree, frozen evidence, independent verification, and guarded integration.
+Use it for direct Codex assistance when those controls are not required. Use `/claude-architect:delegate` when changes need the verified lane and its isolated worktree, frozen Candidate Artifact, independent verification, and guarded integration.
 
 ### Superpowers skill boundary
 

--- a/docs/research/2026-07-27-github-actions-runner-design.md
+++ b/docs/research/2026-07-27-github-actions-runner-design.md
@@ -1,0 +1,153 @@
+# GitHub Actions runner design for current cross-platform CI
+
+Research date: 2026-07-27
+
+## Conclusion
+
+The smallest current matrix for this repository is:
+
+```yaml
+matrix:
+  os: [macos-15, ubuntu-latest, windows-latest]
+```
+
+This keeps the existing three-platform coverage while replacing the deprecated
+`macos-14` leg with stable macOS 15. The important label semantics are:
+
+- `macos-15` is the standard ARM64/M1 macOS 15 runner.
+- `macos-15-intel` is the standard x64/Intel macOS 15 runner.
+- `macos-latest` now targets macOS 26 ARM64, so it is not an alias for macOS 15.
+- `windows-latest` currently targets x64 Windows Server 2025 with Visual Studio
+  2026.
+
+For this repository, `macos-15` is the better default than
+`macos-15-intel`: the current `macos-14` leg is already ARM64, the repository's
+macOS checks are not documented as Intel-specific, and GitHub has announced that
+macOS 15 Intel is its last x86_64 image and is available only through August
+2027. Keep `windows-latest` when the intent is to continuously test GitHub's
+current stable Windows image. Use `windows-2025` instead only if freezing the
+Windows OS generation is a deliberate stability requirement.
+
+Sources:
+
+- [GitHub Docs: standard hosted-runner labels and hardware](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners)
+- [actions/runner-images: current available images and label mappings](https://github.com/actions/runner-images#available-images)
+- [GitHub's macOS 15 Intel support announcement](https://github.com/actions/runner-images/issues/13045)
+- [GitHub's macOS 14 deprecation announcement](https://github.com/actions/runner-images/issues/13518)
+
+## macOS 15 labels and architectures
+
+GitHub's current standard-runner table assigns:
+
+| Workflow label | OS | Architecture | Standard hardware |
+| --- | --- | --- | --- |
+| `macos-15` | macOS 15 | ARM64, Apple M1 | 3 CPUs, 7 GB RAM |
+| `macos-15-intel` | macOS 15 | x64, Intel | 4 CPUs, 14 GB RAM |
+
+`macos-15-arm64` is the runner-image/release name, not the standard workflow
+label. The workflow label is `macos-15`. The current ARM64 image includes Node
+22, although `actions/setup-node` should remain the source of truth for this
+repository's requested Node 22 toolchain.
+
+GitHub began moving `macos-latest` from macOS 15 to macOS 26 on June 15, 2026
+and the live runner table now maps it to macOS 26 ARM64. Pinning `macos-15` is
+therefore required when the acceptance criterion is specifically macOS 15.
+
+Sources:
+
+- [GitHub Docs: public and private standard runner specifications](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#choosing-github-hosted-runners)
+- [Current macOS 15 ARM64 image contents](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md)
+- [GitHub Actions image migration notice](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/)
+
+## Windows labels and the x64 helper
+
+The live runner-image table maps all three of these labels to the same x64
+Windows Server 2025 image with Visual Studio 2026:
+
+- `windows-latest`
+- `windows-2025`
+- `windows-2025-vs2026`
+
+The migration completed in June 2026. GitHub documents the current image as
+including Visual Studio Enterprise 2026, the native desktop workload, and
+`Microsoft.VisualStudio.Component.VC.Tools.x86.x64`. That is the correct hosted
+environment for the workflow's `cl` build of
+`native/bin/win32-job-kill-x64.exe`. Node 22 is also present, but the explicit
+`actions/setup-node` step remains appropriate and consistent across all matrix
+legs.
+
+The label choice is a maintenance policy:
+
+- `windows-latest` follows GitHub's newest stable Windows image. GitHub warns
+  that a `-latest` migration is gradual and may change the OS during a one-to-two
+  month rollout. This is appropriate when CI is intended to continuously test
+  the current GitHub-hosted Windows platform.
+- `windows-2025` freezes the OS generation, avoiding a future move to the next
+  Windows Server release. It does not freeze the entire toolchain: GitHub moved
+  both `windows-latest` and `windows-2025` from Visual Studio 2022 to Visual
+  Studio 2026 in June 2026, and hosted images continue to receive weekly
+  software updates.
+- `windows-2022` is the deliberate compatibility lane for consumers that still
+  require Visual Studio 2022. This repository has no such stated contract.
+
+Sources:
+
+- [actions/runner-images: label scheme and migration behavior](https://github.com/actions/runner-images#label-scheme)
+- [Windows Server 2025 and Visual Studio 2026 migration announcement](https://github.com/actions/runner-images/issues/14017)
+- [Current Windows Server 2025 image contents](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md)
+
+## First-party action versions
+
+The workflow's existing first-party majors are already current and appropriate
+for GitHub-hosted runners:
+
+```yaml
+- uses: actions/checkout@v7
+- uses: actions/setup-node@v7
+  with: { node-version: 22 }
+- uses: actions/upload-artifact@v7
+```
+
+As of the research date:
+
+| Action | Latest release | Published |
+| --- | --- | --- |
+| `actions/checkout` | `v7.0.1` | 2026-07-20 |
+| `actions/setup-node` | `v7.0.0` | 2026-07-14 |
+| `actions/upload-artifact` | `v7.0.1` | 2026-04-10 |
+
+All three v7 actions run their own action implementation on Node 24. That is
+independent of `setup-node` installing Node 22 for this repository's commands.
+The Node 24 action runtime requires Actions Runner 2.327.1 or newer; this matters
+for self-hosted runners, not the GitHub-hosted matrix used here.
+
+The existing uses are compatible with their v7 behavior:
+
+- `checkout@v7` requires no input change for ordinary `push` and
+  `pull_request` checkout.
+- `setup-node@v7` supports `node-version: 22`; its v7 breaking change is the
+  migration to ESM.
+- `upload-artifact@v7` supports the current single x64 executable upload,
+  artifact name, and `if-no-files-found: error`.
+
+Sources:
+
+- [`actions/checkout` v7.0.1 release](https://github.com/actions/checkout/releases/tag/v7.0.1)
+- [`actions/checkout` v7 README](https://github.com/actions/checkout/blob/v7/README.md)
+- [`actions/setup-node` v7.0.0 release](https://github.com/actions/setup-node/releases/tag/v7.0.0)
+- [`actions/setup-node` v7 README](https://github.com/actions/setup-node/blob/v7/README.md)
+- [`actions/upload-artifact` v7.0.1 release](https://github.com/actions/upload-artifact/releases/tag/v7.0.1)
+- [`actions/upload-artifact` v7 README](https://github.com/actions/upload-artifact/blob/v7/README.md)
+
+## Recommended workflow scope
+
+Only the matrix label needs to change for the requested refresh:
+
+```diff
+-        os: [macos-14, ubuntu-latest, windows-latest]
++        os: [macos-15, ubuntu-latest, windows-latest]
+```
+
+No additional macOS Intel leg is justified by the repository's current
+contracts, and no Windows label change is required to exercise Windows Server
+2025, Visual Studio 2026, the x64 MSVC compiler, and Node 22.

--- a/docs/superpowers/specs/2026-07-27-pr-23-ci-and-review-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-27-pr-23-ci-and-review-cleanup-design.md
@@ -1,0 +1,196 @@
+# PR 23 CI and Review Cleanup Design
+
+Date: 2026-07-27
+Status: approved
+Pull request: #23 (`feat/vendor-codex-skill`)
+
+## Goal
+
+Finish the existing direct-Codex-skill pull request in place by updating its
+cross-platform CI matrix, repairing the macOS bootstrap-test race, and
+addressing every unresolved review finding without changing the plugin's
+runtime, protocols, release version, or trust model.
+
+## Ground Truth
+
+- The pull request currently has seven unresolved CodeRabbit threads and a
+  `CHANGES_REQUESTED` review.
+- The current `macos-14` CI leg failed
+  `runtime bootstrap > forwards SIGIO to a re-executed server` because the test
+  can send `SIGIO` after the child publishes its PID but before the bootstrap
+  parent has installed its forwarding handlers. macOS discards an early
+  `SIGIO`, so the child remains alive and the test times out.
+- The focused bootstrap smoke test passes locally, which is consistent with a
+  scheduler-dependent readiness race rather than a deterministic product
+  failure.
+- GitHub's current hosted-runner contract uses `macos-15` for the standard
+  Apple Silicon macOS 15 image. `windows-latest` currently exercises the x64
+  Windows Server 2025 image with the MSVC x86/x64 toolchain needed by this
+  repository.
+- The workflow's existing `actions/checkout@v7`,
+  `actions/setup-node@v7`, and `actions/upload-artifact@v7` majors are current.
+  The project remains on Node 22.
+- Current Codex CLI documentation treats `--full-auto` as deprecated
+  compatibility syntax, documents explicit sandbox selection, streams progress
+  and diagnostics to stderr, and accepts a positional prompt for both a new
+  `exec` run and `exec resume`.
+
+The supporting first-party-source review is recorded in
+`docs/research/2026-07-27-github-actions-runner-design.md`.
+
+## Authorized Scope
+
+Repository changes are limited to:
+
+- `.github/workflows/ci.yml`;
+- `skills/codex/SKILL.md`;
+- `tests/runtime/plugin-wiring.test.mjs`;
+- `tests/runtime/bootstrap.smoke.test.ts`;
+- the pull request's existing `README.md` and `CHANGELOG.md` additions;
+- this design and its supporting research note;
+- a test-first implementation plan derived from this design.
+
+The pull request body and review-thread replies may be updated after the
+verified branch is pushed so they describe the final bytes accurately.
+
+No `src/`, generated `runtime/`, schema, protocol, dependency, plugin-version,
+or release-version change is authorized or required by this design.
+
+## CI Runner Design
+
+Use this three-platform matrix:
+
+```yaml
+matrix:
+  os: [macos-15, ubuntu-latest, windows-latest]
+```
+
+Only `macos-14` changes to `macos-15`.
+
+- Pin macOS 15 because `macos-latest` no longer means macOS 15.
+- Preserve the current Apple Silicon architecture rather than add an
+  Intel-only compatibility lane with no repository contract behind it.
+- Keep `windows-latest` so CI continuously checks GitHub's supported current
+  Windows image. Do not pin `windows-2025` or add `windows-2022` without a
+  Windows-generation or Visual Studio 2022 compatibility requirement.
+- Keep Node 22 and the existing action majors unchanged.
+
+## macOS Bootstrap-Test Repair
+
+Repair the test's readiness protocol rather than adding a sleep or weakening
+the timeout.
+
+The re-executed test server will use a harmless first forwarded `SIGIO` as a
+readiness acknowledgement while it is unarmed. The test will retry `SIGIO`
+until that acknowledgement exists. It will then arm the server through a
+separate temporary marker and send the decisive `SIGIO`, which must still be
+forwarded, recorded, and reflected as the expected bootstrap exit status.
+
+This establishes both necessary conditions:
+
+1. the bootstrap's forwarding handler is demonstrably installed before the
+   decisive assertion; and
+2. the decisive signal must traverse the bootstrap-to-server path for the test
+   to pass.
+
+Polling is bounded and condition-based. There is no arbitrary delay and no
+production-code change. The test must be mutation-checked by temporarily
+breaking the forwarding expectation and observing the focused test fail before
+the final implementation is restored.
+
+## Review-Finding Resolution
+
+The implementation will account for all seven unresolved threads:
+
+1. Replace the inaccurate phrase "isolated production" with "isolated
+   worktree" in both README and changelog text.
+2. Remove `--full-auto` from the skill rather than preserve deprecated hidden
+   compatibility syntax. Use explicit `--sandbox read-only`,
+   `--sandbox workspace-write`, or `--sandbox danger-full-access`.
+3. Include `--skip-git-repo-check` consistently in the documented new-run,
+   alternate-directory, and resume commands because the skill requires Codex
+   to operate in bounded harness and plugin contexts that may not expose the
+   checkout as a normal trusted repository.
+4. Stop discarding stderr. Host integrations must capture it separately,
+   retain failures and warnings, and may summarize progress only after the
+   command's exit status and diagnostics are known.
+5. Prefer positional prompt arguments for manual new and resumed runs. For
+   harnesses that might leave stdin open, require an explicitly closed stdin:
+   a process API with stdin ignored is normative, with accurate POSIX,
+   PowerShell, and `cmd.exe` shell forms documented.
+6. Extend plugin-wiring contract tests so the canonical examples prove explicit
+   sandbox selection, the repo-check flag, preserved stderr, positional resume,
+   and cross-platform closed-stdin guidance.
+7. Strengthen the delegation-boundary test to prove the verified delegation
+   lane remains the only reviewed and independently verified path, while the
+   direct Codex convenience skill never claims that status.
+
+The pull request description must no longer claim that the final skill is
+byte-identical to the older upstream text once these executable-contract fixes
+land.
+
+## Error Handling and Cross-Platform Constraints
+
+- A shell example must not imply that POSIX redirection works in PowerShell or
+  `cmd.exe`.
+- Stdin closure must not also suppress stderr.
+- A nonzero Codex exit remains a failure even when stdout contains a final
+  message.
+- The bootstrap test must fail with a bounded, actionable timeout when its
+  readiness acknowledgement never appears.
+- Windows CI must still build and upload `native/bin/win32-job-kill-x64.exe`;
+  the matrix change must not alter the conditional MSVC or artifact steps.
+- No review thread is resolved until its fix exists on the verified remote head
+  and its reply identifies the change.
+
+## Test-First Implementation Order
+
+1. Add or strengthen narrow contract assertions for each Codex-skill review
+   finding and confirm they fail against the current skill.
+2. Add the condition-based bootstrap test protocol and mutation-check that the
+   focused test detects broken forwarding.
+3. Make the smallest skill, README, changelog, and workflow edits that satisfy
+   those tests.
+4. Run focused tests, then the repository-wide verification gates.
+5. Push one reviewed branch head and require all checks and review surfaces to
+   evaluate that exact SHA.
+
+## Verification
+
+Local verification:
+
+```bash
+npx tsc --noEmit
+npx vitest run
+bash scripts/validate-release.sh
+claude plugin validate .
+```
+
+Also run focused bootstrap and plugin-wiring tests during red/green development,
+inspect the complete diff, and confirm `git status` contains only explained
+changes.
+
+Remote verification on the final pushed SHA:
+
+- `macos-15` green;
+- `ubuntu-latest` green;
+- `windows-latest` green, including the x64 helper build and artifact upload;
+- substantive CodeRabbit review complete with no unresolved actionable
+  findings;
+- every review thread replied to and resolved only after its fix is present;
+- pull request metadata and description accurately describe the final branch.
+
+The pull request is not merged by this task.
+
+## Acceptance Criteria
+
+- The CI matrix is exactly
+  `[macos-15, ubuntu-latest, windows-latest]`.
+- The `SIGIO` smoke test waits on observable forwarding readiness and remains
+  capable of failing when signal forwarding is broken.
+- All seven review findings are fixed and covered at the narrowest appropriate
+  layer.
+- The direct Codex skill uses current CLI semantics and does not weaken or
+  misrepresent the verified delegation boundary.
+- All local and remote verification gates pass on one exact commit.
+- No unrelated user change is modified or discarded.

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -9,7 +9,7 @@ Always present this skill as `/claude-architect:codex`. Never show a shorter com
 
 ## Trust boundary
 
-`/claude-architect:codex` is the direct, unverified lane: it runs `codex exec` against the user's checkout without an isolated worktree, frozen Candidate Artifact, or independent verification. Use it for direct CLI assistance when those controls are not required; use `/claude-architect:delegate` for the verified lane when changes need isolation, frozen evidence, independent verification, and controlled integration.
+`/claude-architect:codex` is the direct, unverified lane: it runs `codex exec` against the user's checkout without an isolated worktree, frozen Candidate Artifact, or independent verification. Use it for direct CLI assistance when those controls are not required. Use `/claude-architect:delegate` for the verified lane when changes need isolation, a frozen Candidate Artifact, independent verification, and controlled integration.
 
 Only `/claude-architect:delegate` produces a frozen, independently verified Candidate Artifact and drives review, decision, and guarded integration. This direct skill must never call itself verified or invoke those lifecycle tools.
 
@@ -48,7 +48,7 @@ Only `/claude-architect:delegate` produces a frozen, independently verified Cand
 | Apply local edits | `codex exec --skip-git-repo-check --sandbox workspace-write "prompt"` |
 | Permit network or broad access | `codex exec --skip-git-repo-check --sandbox danger-full-access "prompt"` |
 | Resume recent session | `codex exec --skip-git-repo-check resume --last "prompt"` |
-| Run from another directory | `codex exec --skip-git-repo-check -C <DIR> --sandbox read-only "prompt"` |
+| Run from an explicit directory | `codex exec --skip-git-repo-check -C . --sandbox read-only "prompt"` |
 
 ## Execution timeouts
 

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: codex
+description: Run the Codex CLI directly in the user's checkout for code analysis, refactoring, or automated editing without Claude Architect's verified delegation lifecycle.
+---
+
+# Codex Skill Guide
+
+Always present this skill as `/claude-architect:codex`. Never show a shorter command.
+
+## Trust boundary
+
+`/claude-architect:codex` is the direct, unverified lane: it runs `codex exec` against the user's checkout without an isolated worktree, frozen Candidate Artifact, or independent verification. Use it for direct CLI assistance when those controls are not required; use `/claude-architect:delegate` for the verified lane when changes need isolation, frozen evidence, independent verification, and controlled integration.
+
+## Running a Task
+1. For a new session (resumes inherit the prior model/effort — see step 5), ask the user (via `AskUserQuestion`) which **model** AND which **reasoning effort** to use, in a **single prompt with two questions**. When the user expresses no preference, default to `gpt-5.6-sol` at `high`.
+   - **Model** — default `gpt-5.6-sol`:
+     - *GPT-5.6:* `gpt-5.6-sol` (frontier / most capable — **default**), `gpt-5.6-terra` (balanced, everyday), `gpt-5.6-luna` (fast & affordable)
+     - *Legacy (kept for compatibility):* `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, `gpt-5.3-codex`
+   - **Reasoning effort** — default `high`: `low`, `medium`, `high`, `xhigh`, `max`, `ultra`.
+     - `max`/`ultra` require a GPT-5.6 model; `ultra` is only on `sol`/`terra` (`luna` caps at `max`); legacy models cap at `xhigh`.
+     - `ultra` = maximum reasoning **with automatic task delegation** (slowest and most expensive — reserve for the hardest jobs).
+     - If the chosen effort exceeds the chosen model's maximum, fall back to that model's highest supported effort and tell the user.
+2. Select the sandbox mode required for the task; default to `--sandbox read-only` unless edits or network access are necessary.
+3. Assemble the command with the appropriate options:
+   - `-m, --model <MODEL>`
+   - `--config model_reasoning_effort="<low|medium|high|xhigh|max|ultra>"` (max/ultra only on GPT-5.6 models; ultra only on sol/terra — see step 1)
+   - `--sandbox <read-only|workspace-write|danger-full-access>`
+   - `--full-auto`
+   - `-C, --cd <DIR>`
+   - `--skip-git-repo-check`
+   - `"your prompt here"` (as final positional argument)
+4. Always use --skip-git-repo-check.
+5. When continuing a previous session, use `codex exec --skip-git-repo-check resume --last` via stdin. When resuming don't use any configuration flags unless explicitly requested by the user e.g. if he species the model or the reasoning effort when requesting to resume a session. Resume syntax: `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. All flags have to be inserted between exec and resume.
+6. **IMPORTANT**: By default, append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests to see thinking tokens or if debugging is needed.
+7. **IMPORTANT (stdin)**: `codex exec` always reads stdin and concatenates it with the positional prompt -- even when the prompt is fully supplied as a positional argument. If stdin is not closed, codex blocks forever. When invoking from a harness (background tasks, hooks, scripts where stdin is not a TTY but also not closed), explicitly redirect stdin: append `</dev/null` to the command, e.g. `codex exec ... "prompt" </dev/null 2>/dev/null`. Symptom of getting this wrong: zero bytes of stdout, zero CPU accumulated, process appears hung indefinitely.
+8. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
+9. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
+
+### Quick Reference
+| Use case | Sandbox mode | Key flags |
+| --- | --- | --- |
+| Read-only review or analysis | `read-only` | `--sandbox read-only 2>/dev/null` |
+| Apply local edits | `workspace-write` | `--sandbox workspace-write --full-auto 2>/dev/null` |
+| Permit network or broad access | `danger-full-access` | `--sandbox danger-full-access --full-auto 2>/dev/null` |
+| Resume recent session | Inherited from original | `echo "prompt" \| codex exec --skip-git-repo-check resume --last 2>/dev/null` (no flags allowed) |
+| Run from another directory | Match task needs | `-C <DIR>` plus other flags `2>/dev/null` |
+
+## Execution timeouts
+
+Codex produces **no intermediate output** — it writes the result only at completion. If the process is killed before finishing, the output file is silently empty (no error).
+
+**Preferred approach:** run synchronously — eliminates timeout risk entirely and the conversation waits for the result anyway.
+
+**If running in background**, set the execution timeout based on reasoning effort:
+
+| Reasoning effort | Timeout |
+|---|---|
+| `low` | 150s |
+| `medium` | 300s |
+| `high` | 600s |
+| `xhigh` | 1200s |
+| `max` | 1800s |
+| `ultra` | 1800s |
+
+## Following Up
+- After every `codex` command, immediately use `AskUserQuestion` to confirm next steps, collect clarifications, or decide whether to resume with `codex exec resume --last`.
+- When resuming, pipe the new prompt via stdin: `echo "new prompt" | codex exec resume --last 2>/dev/null`. The resumed session automatically uses the same model, reasoning effort, and sandbox mode from the original session.
+- Restate the chosen model, reasoning effort, and sandbox mode when proposing follow-up actions.
+
+## Critical Evaluation of Codex Output
+
+Codex is powered by OpenAI models with their own knowledge cutoffs and limitations. Treat Codex as a **colleague, not an authority**.
+
+### Guidelines
+- **Trust your own knowledge** when confident. If Codex claims something you know is incorrect, push back directly.
+- **Research disagreements** using WebSearch or documentation before accepting Codex's claims. Share findings with Codex via resume if needed.
+- **Remember knowledge cutoffs** - Codex may not know about recent releases, APIs, or changes that occurred after its training data.
+- **Don't defer blindly** - Codex can be wrong. Evaluate its suggestions critically, especially regarding:
+  - Model names and capabilities
+  - Recent library versions or API changes
+  - Best practices that may have evolved
+
+### When Codex is Wrong
+1. State your disagreement clearly to the user
+2. Provide evidence (your own knowledge, web search, docs)
+3. Optionally resume the Codex session to discuss the disagreement. **Identify yourself as Claude** so Codex knows it's a peer AI discussion. Use your actual model name (e.g., the model you are currently running as) instead of a hardcoded name:
+   ```bash
+   echo "This is Claude (<your current model name>) following up. I disagree with [X] because [evidence]. What's your take on this?" | codex exec --skip-git-repo-check resume --last 2>/dev/null
+   ```
+4. Frame disagreements as discussions, not corrections - either AI could be wrong
+5. Let the user decide how to proceed if there's genuine ambiguity
+
+## Error Handling
+- Stop and report failures whenever `codex --version` or a `codex exec` command exits non-zero; request direction before retrying.
+- Before you use high-impact flags (`--full-auto`, `--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using AskUserQuestion unless it was already given.
+- When output includes warnings or partial results, summarize them and ask how to adjust using `AskUserQuestion`.

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -11,6 +11,8 @@ Always present this skill as `/claude-architect:codex`. Never show a shorter com
 
 `/claude-architect:codex` is the direct, unverified lane: it runs `codex exec` against the user's checkout without an isolated worktree, frozen Candidate Artifact, or independent verification. Use it for direct CLI assistance when those controls are not required; use `/claude-architect:delegate` for the verified lane when changes need isolation, frozen evidence, independent verification, and controlled integration.
 
+Only `/claude-architect:delegate` produces a frozen, independently verified Candidate Artifact and drives review, decision, and guarded integration. This direct skill must never call itself verified or invoke those lifecycle tools.
+
 ## Running a Task
 1. For a new session (resumes inherit the prior model/effort — see step 5), ask the user (via `AskUserQuestion`) which **model** AND which **reasoning effort** to use, in a **single prompt with two questions**. When the user expresses no preference, default to `gpt-5.6-sol` at `high`.
    - **Model** — default `gpt-5.6-sol`:
@@ -25,29 +27,32 @@ Always present this skill as `/claude-architect:codex`. Never show a shorter com
    - `-m, --model <MODEL>`
    - `--config model_reasoning_effort="<low|medium|high|xhigh|max|ultra>"` (max/ultra only on GPT-5.6 models; ultra only on sol/terra — see step 1)
    - `--sandbox <read-only|workspace-write|danger-full-access>`
-   - `--full-auto`
    - `-C, --cd <DIR>`
    - `--skip-git-repo-check`
    - `"your prompt here"` (as final positional argument)
 4. Always use --skip-git-repo-check.
-5. When continuing a previous session, use `codex exec --skip-git-repo-check resume --last` via stdin. When resuming don't use any configuration flags unless explicitly requested by the user e.g. if he species the model or the reasoning effort when requesting to resume a session. Resume syntax: `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. All flags have to be inserted between exec and resume.
-6. **IMPORTANT**: By default, append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests to see thinking tokens or if debugging is needed.
-7. **IMPORTANT (stdin)**: `codex exec` always reads stdin and concatenates it with the positional prompt -- even when the prompt is fully supplied as a positional argument. If stdin is not closed, codex blocks forever. When invoking from a harness (background tasks, hooks, scripts where stdin is not a TTY but also not closed), explicitly redirect stdin: append `</dev/null` to the command, e.g. `codex exec ... "prompt" </dev/null 2>/dev/null`. Symptom of getting this wrong: zero bytes of stdout, zero CPU accumulated, process appears hung indefinitely.
-8. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
+5. When continuing a previous session, prefer the positional form `codex exec --skip-git-repo-check resume --last "prompt"`. Resumed sessions inherit the prior model, reasoning effort, and sandbox. Do not add configuration flags unless the user explicitly requests an override; any such flags belong between `exec` and `resume`.
+6. **IMPORTANT (stderr)**: Never discard stderr. `codex exec` sends progress, warnings, and diagnostics to stderr and its final agent message to stdout. Capture both streams separately, preserve a nonzero exit as failure, and summarize progress only after retaining actionable diagnostics.
+7. **IMPORTANT (stdin)**: Prefer a positional prompt for new and resumed sessions. In a harness that may leave stdin open, close it explicitly without redirecting stderr:
+   - POSIX: append `</dev/null`, for example `codex exec --skip-git-repo-check --sandbox read-only "prompt" </dev/null`.
+   - PowerShell: prefix the native command with `$null |`, for example `$null | codex exec --skip-git-repo-check --sandbox read-only "prompt"`.
+   - `cmd.exe`: append `<NUL`, for example `codex exec --skip-git-repo-check --sandbox read-only "prompt" <NUL`.
+   - Process APIs: spawn with `stdio: ["ignore", "pipe", "pipe"]` so stdin is closed while stdout and stderr remain distinct.
+8. Run the command, capture stdout and stderr separately, and summarize the outcome for the user.
 9. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
 
 ### Quick Reference
-| Use case | Sandbox mode | Key flags |
-| --- | --- | --- |
-| Read-only review or analysis | `read-only` | `--sandbox read-only 2>/dev/null` |
-| Apply local edits | `workspace-write` | `--sandbox workspace-write --full-auto 2>/dev/null` |
-| Permit network or broad access | `danger-full-access` | `--sandbox danger-full-access --full-auto 2>/dev/null` |
-| Resume recent session | Inherited from original | `echo "prompt" \| codex exec --skip-git-repo-check resume --last 2>/dev/null` (no flags allowed) |
-| Run from another directory | Match task needs | `-C <DIR>` plus other flags `2>/dev/null` |
+| Use case | Command |
+| --- | --- |
+| Read-only review or analysis | `codex exec --skip-git-repo-check --sandbox read-only "prompt"` |
+| Apply local edits | `codex exec --skip-git-repo-check --sandbox workspace-write "prompt"` |
+| Permit network or broad access | `codex exec --skip-git-repo-check --sandbox danger-full-access "prompt"` |
+| Resume recent session | `codex exec --skip-git-repo-check resume --last "prompt"` |
+| Run from another directory | `codex exec --skip-git-repo-check -C <DIR> --sandbox read-only "prompt"` |
 
 ## Execution timeouts
 
-Codex produces **no intermediate output** — it writes the result only at completion. If the process is killed before finishing, the output file is silently empty (no error).
+Codex streams intermediate progress to stderr and writes the final agent message to stdout. An empty stdout does not prove the process is hung; inspect retained stderr and the process state. If the process is killed before finishing, treat the run as failed even if it emitted partial output.
 
 **Preferred approach:** run synchronously — eliminates timeout risk entirely and the conversation waits for the result anyway.
 
@@ -64,7 +69,7 @@ Codex produces **no intermediate output** — it writes the result only at compl
 
 ## Following Up
 - After every `codex` command, immediately use `AskUserQuestion` to confirm next steps, collect clarifications, or decide whether to resume with `codex exec resume --last`.
-- When resuming, pipe the new prompt via stdin: `echo "new prompt" | codex exec resume --last 2>/dev/null`. The resumed session automatically uses the same model, reasoning effort, and sandbox mode from the original session.
+- When resuming, pass the new prompt positionally: `codex exec --skip-git-repo-check resume --last "new prompt"`. The resumed session automatically uses the same model, reasoning effort, and sandbox mode from the original session.
 - Restate the chosen model, reasoning effort, and sandbox mode when proposing follow-up actions.
 
 ## Critical Evaluation of Codex Output
@@ -85,12 +90,12 @@ Codex is powered by OpenAI models with their own knowledge cutoffs and limitatio
 2. Provide evidence (your own knowledge, web search, docs)
 3. Optionally resume the Codex session to discuss the disagreement. **Identify yourself as Claude** so Codex knows it's a peer AI discussion. Use your actual model name (e.g., the model you are currently running as) instead of a hardcoded name:
    ```bash
-   echo "This is Claude (<your current model name>) following up. I disagree with [X] because [evidence]. What's your take on this?" | codex exec --skip-git-repo-check resume --last 2>/dev/null
+   codex exec --skip-git-repo-check resume --last "This is Claude (<your current model name>) following up. I disagree with [X] because [evidence]. What's your take on this?"
    ```
 4. Frame disagreements as discussions, not corrections - either AI could be wrong
 5. Let the user decide how to proceed if there's genuine ambiguity
 
 ## Error Handling
 - Stop and report failures whenever `codex --version` or a `codex exec` command exits non-zero; request direction before retrying.
-- Before you use high-impact flags (`--full-auto`, `--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using AskUserQuestion unless it was already given.
+- Before you use high-impact flags (`--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using AskUserQuestion unless it was already given.
 - When output includes warnings or partial results, summarize them and ask how to adjust using `AskUserQuestion`.

--- a/tests/runtime/bootstrap.smoke.test.ts
+++ b/tests/runtime/bootstrap.smoke.test.ts
@@ -305,16 +305,22 @@ describe("runtime bootstrap", () => {
     const bin = path.join(root, "bin");
     const serverPath = path.join(root, "signal-server.mjs");
     const pidFile = path.join(root, "server.pid");
+    const readyFile = path.join(root, "signal.ready");
+    const armFile = path.join(root, "signal.arm");
     const signalFile = path.join(root, "signal.txt");
     await mkdir(bin);
     await symlink(process.execPath, path.join(bin, "node"));
     await writeFile(serverPath, [
-      "import { writeFileSync } from 'node:fs';",
-      "writeFileSync(process.env.TEST_SERVER_PID_FILE, String(process.pid));",
+      "import { existsSync, writeFileSync } from 'node:fs';",
       "process.on('SIGIO', () => {",
+      "  if (!existsSync(process.env.TEST_SIGNAL_ARM_FILE)) {",
+      "    writeFileSync(process.env.TEST_SIGNAL_READY_FILE, 'ready');",
+      "    return;",
+      "  }",
       "  writeFileSync(process.env.TEST_SIGNAL_FILE, 'SIGIO');",
       "  process.exit(47);",
       "});",
+      "writeFileSync(process.env.TEST_SERVER_PID_FILE, String(process.pid));",
       "setInterval(() => {}, 1000);",
       "",
     ].join("\n"));
@@ -325,6 +331,8 @@ describe("runtime bootstrap", () => {
         PATH: bin,
         CLAUDE_ARCHITECT_SERVER_PATH: serverPath,
         TEST_SERVER_PID_FILE: pidFile,
+        TEST_SIGNAL_READY_FILE: readyFile,
+        TEST_SIGNAL_ARM_FILE: armFile,
         TEST_SIGNAL_FILE: signalFile,
       },
       stdio: ["ignore", "pipe", "pipe"],
@@ -332,6 +340,16 @@ describe("runtime bootstrap", () => {
     let serverPid = 0;
     try {
       serverPid = Number(await waitForFile(pidFile));
+      const readiness = waitForFile(readyFile);
+      const readinessProbe = setInterval(() => {
+        if (child.exitCode === null && child.signalCode === null) child.kill("SIGIO");
+      }, 20);
+      try {
+        await readiness;
+      } finally {
+        clearInterval(readinessProbe);
+      }
+      await writeFile(armFile, "armed");
       child.kill("SIGIO");
       const exit = await waitForExit(child);
       await waitForProcessGone(serverPid);

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -397,6 +397,21 @@ test("codex skill ships the direct CLI lane without obscuring its trust boundary
     "README must not describe a worktree as production");
 });
 
+test("CI exercises the supported macOS 15, Ubuntu, and Windows runners", () => {
+  const workflow = read(".github/workflows/ci.yml");
+  assert.match(
+    workflow,
+    /os:\s*\[macos-15,\s*ubuntu-latest,\s*windows-latest\]/u,
+    "CI must test the approved three-platform runner matrix",
+  );
+  assert.doesNotMatch(workflow, /macos-14/u);
+  assert.match(workflow, /actions\/checkout@v7/u);
+  assert.match(workflow, /actions\/setup-node@v7/u);
+  assert.match(workflow, /node-version:\s*22/u);
+  assert.match(workflow, /actions\/upload-artifact@v7/u);
+  assert.match(workflow, /win32-job-kill-x64\.exe/u);
+});
+
 test("delegation-lane agent ships the produce-only courier contract", () => {
   const lane = read("agents/delegation-lane.md");
   const frontmatterMatch = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/u.exec(lane);

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -348,14 +348,41 @@ test("codex skill ships the direct CLI lane without obscuring its trust boundary
     "codex skill must retain the current default model and effort");
   assert.match(skill, /Always use --skip-git-repo-check\./u,
     "codex skill must require the repository-check override");
+  assert.doesNotMatch(skill, /--full-auto/u,
+    "codex skill must use explicit sandbox modes instead of deprecated full-auto");
+  assert.doesNotMatch(skill, /2>\/dev\/null/u,
+    "codex skill must preserve stderr diagnostics");
+  for (const command of [
+    "codex exec --skip-git-repo-check --sandbox read-only \"prompt\"",
+    "codex exec --skip-git-repo-check --sandbox workspace-write \"prompt\"",
+    "codex exec --skip-git-repo-check --sandbox danger-full-access \"prompt\"",
+    "codex exec --skip-git-repo-check -C <DIR> --sandbox read-only \"prompt\"",
+    "codex exec --skip-git-repo-check resume --last \"prompt\"",
+  ]) {
+    assert.ok(skill.includes(`\`${command}\``), `codex skill must ship ${command}`);
+  }
   assert.match(skill, /<\/dev\/null/u,
     "codex skill must document closing stdin for harness invocation");
+  assert.match(skill, /POSIX[^]*<\/dev\/null/u,
+    "codex skill must document POSIX stdin closure");
+  assert.match(skill, /PowerShell[^]*\$null \| codex exec/u,
+    "codex skill must document PowerShell stdin closure");
+  assert.match(skill, /cmd\.exe[^]*<NUL/u,
+    "codex skill must document cmd.exe stdin closure");
+  assert.match(skill, /stdio:\s*\["ignore",\s*"pipe",\s*"pipe"\]/u,
+    "codex skill must document portable process stdin closure");
   assert.match(skill, /direct, unverified lane/u,
     "codex skill must identify itself as unverified");
   assert.match(skill, /\/claude-architect:delegate[^.\n]*verified lane/u,
     "codex skill must point users to verified delegation");
+  assert.match(skill, /Only `\/claude-architect:delegate`[^.]*independently verified/u,
+    "codex skill must reserve independent verification for the delegation lane");
+  assert.match(skill, /direct skill must never call itself verified/u,
+    "codex skill must reject verified-lane claims");
   assert.doesNotMatch(skill, /claude-architect-protocol|PROTOCOL_VERSION/u,
     "direct Codex execution must not claim delegation protocol membership");
+  assert.doesNotMatch(skill, /isolated production/u,
+    "codex skill must use the worktree terminology");
 
   const readme = read("README.md");
   assert.match(readme, /\/claude-architect:codex/u,
@@ -364,6 +391,10 @@ test("codex skill ships the direct CLI lane without obscuring its trust boundary
     "README must never advertise a bare Codex command");
   assert.match(readme, /direct, unverified Codex CLI lane/u,
     "README must distinguish direct Codex execution from verified delegation");
+  assert.match(readme, /isolated worktree/u,
+    "README must name the verified lane's isolation boundary");
+  assert.doesNotMatch(readme, /isolated production/u,
+    "README must not describe a worktree as production");
 });
 
 test("delegation-lane agent ships the produce-only courier contract", () => {

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -352,11 +352,16 @@ test("codex skill ships the direct CLI lane without obscuring its trust boundary
     "codex skill must use explicit sandbox modes instead of deprecated full-auto");
   assert.doesNotMatch(skill, /2>\/dev\/null/u,
     "codex skill must preserve stderr diagnostics");
+  assert.match(
+    skill,
+    /Capture both streams separately, preserve a nonzero exit as failure,[^.\n]*retaining actionable diagnostics/u,
+    "codex skill must retain separate stdout and stderr diagnostics on failure",
+  );
   for (const command of [
     "codex exec --skip-git-repo-check --sandbox read-only \"prompt\"",
     "codex exec --skip-git-repo-check --sandbox workspace-write \"prompt\"",
     "codex exec --skip-git-repo-check --sandbox danger-full-access \"prompt\"",
-    "codex exec --skip-git-repo-check -C <DIR> --sandbox read-only \"prompt\"",
+    "codex exec --skip-git-repo-check -C . --sandbox read-only \"prompt\"",
     "codex exec --skip-git-repo-check resume --last \"prompt\"",
   ]) {
     assert.ok(skill.includes(`\`${command}\``), `codex skill must ship ${command}`);
@@ -373,12 +378,18 @@ test("codex skill ships the direct CLI lane without obscuring its trust boundary
     "codex skill must document portable process stdin closure");
   assert.match(skill, /direct, unverified lane/u,
     "codex skill must identify itself as unverified");
-  assert.match(skill, /\/claude-architect:delegate[^.\n]*verified lane/u,
+  assert.ok(
+    skill.includes("Use `/claude-architect:delegate` for the verified lane"),
     "codex skill must point users to verified delegation");
   assert.match(skill, /Only `\/claude-architect:delegate`[^.]*independently verified/u,
     "codex skill must reserve independent verification for the delegation lane");
   assert.match(skill, /direct skill must never call itself verified/u,
     "codex skill must reject verified-lane claims");
+  assert.doesNotMatch(
+    skill,
+    /(?:direct(?: Codex(?: CLI)?)? lane|direct skill)[^.\n]*\b(?:is|as)\s+(?:independently\s+)?verified\b/iu,
+    "codex skill must fail closed on positive verified-lane claims",
+  );
   assert.doesNotMatch(skill, /claude-architect-protocol|PROTOCOL_VERSION/u,
     "direct Codex execution must not claim delegation protocol membership");
   assert.doesNotMatch(skill, /isolated production/u,
@@ -393,6 +404,11 @@ test("codex skill ships the direct CLI lane without obscuring its trust boundary
     "README must distinguish direct Codex execution from verified delegation");
   assert.match(readme, /isolated worktree/u,
     "README must name the verified lane's isolation boundary");
+  assert.match(
+    readme,
+    /Use `\/claude-architect:delegate`[^.\n]*verified lane[^.\n]*frozen Candidate Artifact/u,
+    "README must name the verified lane's canonical frozen artifact",
+  );
   assert.doesNotMatch(readme, /isolated production/u,
     "README must not describe a worktree as production");
 });

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -329,6 +329,43 @@ test("subagent-driven-delegation skill keeps the trust invariants that upstream 
     "delegate skill must point at the SDD skill for multi-task plans");
 });
 
+test("codex skill ships the direct CLI lane without obscuring its trust boundary", () => {
+  const skillPath = `${root}/skills/codex/SKILL.md`;
+  assert.equal(fs.existsSync(skillPath), true, "codex skill must ship");
+  const skill = read("skills/codex/SKILL.md");
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/u.exec(skill)?.[1] ?? "";
+  const keys = [...frontmatter.matchAll(/^([A-Za-z][A-Za-z0-9]*):/gmu)]
+    .map(match => match[1]);
+  assert.deepEqual(keys, ["name", "description"],
+    "codex skill frontmatter must contain only name and description");
+  assert.match(frontmatter, /^name:\s*codex$/mu);
+
+  assert.match(skill, /\/claude-architect:codex/u,
+    "codex skill must use its plugin-qualified command");
+  assert.doesNotMatch(skill, /(^|[^:])\/codex\b/mu,
+    "codex skill must never present a bare command");
+  assert.match(skill, /default to `gpt-5\.6-sol` at `high`/u,
+    "codex skill must retain the current default model and effort");
+  assert.match(skill, /Always use --skip-git-repo-check\./u,
+    "codex skill must require the repository-check override");
+  assert.match(skill, /<\/dev\/null/u,
+    "codex skill must document closing stdin for harness invocation");
+  assert.match(skill, /direct, unverified lane/u,
+    "codex skill must identify itself as unverified");
+  assert.match(skill, /\/claude-architect:delegate[^.\n]*verified lane/u,
+    "codex skill must point users to verified delegation");
+  assert.doesNotMatch(skill, /claude-architect-protocol|PROTOCOL_VERSION/u,
+    "direct Codex execution must not claim delegation protocol membership");
+
+  const readme = read("README.md");
+  assert.match(readme, /\/claude-architect:codex/u,
+    "README must advertise the plugin-qualified Codex skill");
+  assert.doesNotMatch(readme, /(^|[^:])\/codex\b/mu,
+    "README must never advertise a bare Codex command");
+  assert.match(readme, /direct, unverified Codex CLI lane/u,
+    "README must distinguish direct Codex execution from verified delegation");
+});
+
 test("delegation-lane agent ships the produce-only courier contract", () => {
   const lane = read("agents/delegation-lane.md");
   const frontmatterMatch = /^---\r?\n([\s\S]*?)\r?\n---\r?\n/u.exec(lane);

--- a/tests/runtime/plugin-wiring.test.mjs
+++ b/tests/runtime/plugin-wiring.test.mjs
@@ -390,6 +390,11 @@ test("codex skill ships the direct CLI lane without obscuring its trust boundary
     /(?:direct(?: Codex(?: CLI)?)? lane|direct skill)[^.\n]*\b(?:is|as)\s+(?:independently\s+)?verified\b/iu,
     "codex skill must fail closed on positive verified-lane claims",
   );
+  assert.match(
+    skill,
+    /Before you use high-impact flags[^.\n]*AskUserQuestion[^.\n]*unless it was already given/u,
+    "codex skill must require permission before high-impact flags",
+  );
   assert.doesNotMatch(skill, /claude-architect-protocol|PROTOCOL_VERSION/u,
     "direct Codex execution must not claim delegation protocol membership");
   assert.doesNotMatch(skill, /isolated production/u,


### PR DESCRIPTION
Adds `/claude-architect:codex`, a direct Codex CLI lane that runs `codex exec` against the current checkout.

The skill retains the intended model roster, reasoning-effort ladder, sandbox choices, timeout guidance, follow-up flow, critical-evaluation rules, and error handling while updating command examples to the current executable contract: explicit sandbox modes, positional prompts, consistent `--skip-git-repo-check`, preserved stderr diagnostics, and closed-stdin guidance for POSIX, PowerShell, `cmd.exe`, and portable process APIs.

## Trust boundary

This lane deliberately has none of the delegation trust controls: no isolated worktree, no frozen Candidate Artifact, no independent verification. The skill and README say so plainly and point at `/claude-architect:delegate` for the verified lane.

It carries no `claude-architect-protocol` marker and cannot claim review, decision, or integration authority.

## CI refresh

The hosted-runner matrix is now:

```yaml
os: [macos-15, ubuntu-latest, windows-latest]
```

`macos-15` preserves the existing Apple Silicon architecture while moving off macOS 14. `windows-latest` remains the supported current x64 Windows image and continues to build and upload the native Job Object helper. Existing Node 22 and first-party action majors remain unchanged.

The macOS `SIGIO` bootstrap smoke test now waits for observable forwarding readiness instead of racing the bootstrap handler installation. A mutation check confirmed the test fails when forwarding is disabled.

## Naming

Skills are plugin-qualified, so `claude-architect:codex` coexists with an externally installed `skill-codex:codex`. Following the existing `delegate` convention, the skill never presents a bare command; tests enforce this in both `SKILL.md` and `README.md`.

## Not a release

No version surface moves here and generated `runtime/server.mjs` remains byte-identical to `main`. The changelog entry stays under `[Unreleased]`; cutting `0.42.0` remains a separate release change.

## Coverage

`tests/runtime/plugin-wiring.test.mjs` covers frontmatter shape, plugin-qualified naming, model defaults, current sandbox commands, repo-check flags, preserved stderr, cross-platform stdin closure, the unverified trust boundary, README terminology, and the exact CI runner/action contract.

`tests/runtime/bootstrap.smoke.test.ts` covers readiness and decisive forwarding for `SIGIO`; six repeated focused runs passed, and disabling forwarding produced the expected bounded failure.

Fresh forward tests also exercised read-only, workspace-write, resume, POSIX, Windows, stream-separation, and trust-boundary interpretations against the installed Codex CLI.

## Local verification

| Gate | Result |
|---|---|
| Focused plugin/bootstrap tests | 15 passed |
| `npx tsc --noEmit` | exit 0 |
| `npx vitest run` | 1641 passed, 0 failed, 15 skipped |
| `bash scripts/validate-release.sh` | exit 0 |
| `claude plugin validate .` | exit 0 |

Remote macOS 15, Ubuntu, Windows, CodeQL, and CodeRabbit checks are running against head `e09d5af3d77c2b303d7efe48d8984dafd8af9c16`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Direct Codex CLI** skill at **`/claude-architect:codex`** that runs against the current checkout as **direct, unverified**, clearly distinct from the verified delegation flow at **`...:delegate`**.
* **Documentation**
  * Updated the README and added **`skills/codex/SKILL.md`** with direct-lane invocation, sandbox/timeout guidance, resumable follow-ups, and required stdout/stderr handling to avoid hangs.
* **Tests**
  * Added stricter plugin-wiring and content validation checks, and improved **`runtime bootstrap`** **SIGIO** smoke-test synchronization.
* **CI**
  * Switched the test matrix from **macos-14** to **macos-15**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->